### PR TITLE
BD-2955. NFT validation page.

### DIFF
--- a/client/src/api/fio.ts
+++ b/client/src/api/fio.ts
@@ -287,14 +287,20 @@ export default class Fio {
     return retResult;
   };
 
-  getNFTsFioAddress = async (
-    fioAddress: string,
+  getNFTs = async (
+    searchParams: {
+      fioAddress?: string;
+      chainCode?: string;
+      hash?: string;
+      tokenId?: string;
+      contractAddress?: string;
+    },
     limit: number | null = null,
     offset: number | null = null,
   ): Promise<NftsResponse> => {
     this.setBaseUrl();
     try {
-      return await this.publicFioSDK.getNfts({ fioAddress }, limit, offset);
+      return await this.publicFioSDK.getNfts(searchParams, limit, offset);
     } catch (e) {
       this.logError(e);
     }

--- a/client/src/assets/styles/colors.scss
+++ b/client/src/assets/styles/colors.scss
@@ -31,6 +31,7 @@ $warn-red: #D40000;
 $simple-red: #E33E3E;
 $red: #EB0000;
 $simple-orange: #FF7500;
+$bright-orange: #FF5E00;
 $green: #74F87F;
 $green-main: #00AB59;
 $irish-green:#03B12D;

--- a/client/src/components/Badges/InfoBadge/InfoBadge.module.scss
+++ b/client/src/components/Badges/InfoBadge/InfoBadge.module.scss
@@ -23,4 +23,7 @@
   .infoText {
     font-size: 0.75em;
   }
+  &.isOrange {
+    background-color: $bright-orange;
+  }
 }

--- a/client/src/components/Badges/InfoBadge/InfoBadge.tsx
+++ b/client/src/components/Badges/InfoBadge/InfoBadge.tsx
@@ -1,16 +1,20 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import classnames from 'classnames';
 import classes from './InfoBadge.module.scss';
 
 type Props = {
   title: string;
   message: string;
+  isOrange?: boolean;
 };
 
 const InfoBadge: React.FC<Props> = props => {
-  const { title, message } = props;
+  const { title, message, isOrange } = props;
   return (
-    <div className={classes.infoBadge}>
+    <div
+      className={classnames(classes.infoBadge, isOrange && classes.isOrange)}
+    >
       <FontAwesomeIcon icon="exclamation-circle" className={classes.infoIcon} />
       <h5 className={classes.infoTitle}>{title}</h5>
       <p className={classes.infoText}>{message}</p>

--- a/client/src/components/CustomDropdown/CustomDropdown.module.scss
+++ b/client/src/components/CustomDropdown/CustomDropdown.module.scss
@@ -1,0 +1,79 @@
+@import '../../assets/styles/colors.scss';
+@import '../../assets/styles/fontMixins.scss';
+
+.dropdown {
+  margin-bottom: 30px;
+  width: 100%;
+  min-width: 335px;
+
+  .icon {
+    font-size: 13px;
+    color: $gray-main;
+  }
+}
+
+.control {
+  width: 100%;
+  background-color: $light-gray;
+  border-radius: 7px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  line-height: 15px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: none;
+  cursor: pointer;
+  padding-left: 20px;
+  padding-right: 20px;
+  position: relative;
+  z-index: 1001; //show over menu
+  @include sf-pro-display-medium;
+  box-shadow: 0 0 8px 0 rgba(0,0,0,0.37);
+}
+.placeholder {
+  color: $gray-main;
+}
+.menu {
+  border-radius: 0 0 7px 7px;
+  border: none;
+  box-shadow: 0 0 10px 0 rgba(0,0,0,0.53);
+  margin-top: -7px;
+  padding-top: 7px;
+  max-height: 250px;
+  animation-name: expand;
+  animation-duration: 0.4s;
+}
+
+.optionItem {
+  @include sf-pro-display-medium;
+  margin: 0 auto;
+  font-size: 13px;
+  color: $black;
+  text-align: left;
+  padding: 9px 20px 9px 20px;
+
+  &:after {
+    content: ' ';
+    position: absolute;
+    width: calc(100% - 20px);
+    left: 10px;
+    margin: -9px auto 0;
+    border-bottom: 1px solid $light;
+  }
+
+  &:last-child:after, &:first-child:after {
+    border: none;
+  }
+
+  &:hover {
+    color: $white;
+    background-color: $dark-gray;
+  }
+
+  &:hover:after {
+    border-color: $dark-gray;
+  }
+}

--- a/client/src/components/CustomDropdown/CustomDropdown.tsx
+++ b/client/src/components/CustomDropdown/CustomDropdown.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import Dropdown from 'react-dropdown';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import classes from './CustomDropdown.module.scss';
+
+type Props = {
+  options: { id: string; name: string }[];
+  placeholder?: string;
+  hasDefaultValue?: boolean;
+  onChange: (id: string) => void;
+};
+
+const CustomDropdown: React.FC<Props> = props => {
+  const { options, onChange, placeholder, hasDefaultValue } = props;
+
+  const styledOptions = options.map(option => ({
+    value: option.id,
+    label: option.name,
+    className: classes.optionItem,
+  }));
+  const onDropdownChange = (value: { value: string }) => {
+    const { value: itemValue } = value || {};
+
+    onChange(itemValue);
+  };
+
+  return (
+    <Dropdown
+      options={styledOptions}
+      value={hasDefaultValue ? styledOptions[0] : null}
+      onChange={onDropdownChange}
+      placeholder={placeholder}
+      className={classes.dropdown}
+      controlClassName={classes.control}
+      placeholderClassName={classes.placeholder}
+      menuClassName={classes.menu}
+      arrowClosed={
+        <FontAwesomeIcon icon="chevron-down" className={classes.icon} />
+      }
+      arrowOpen={<FontAwesomeIcon icon="chevron-up" className={classes.icon} />}
+    />
+  );
+};
+
+export default CustomDropdown;

--- a/client/src/components/CustomDropdown/index.ts
+++ b/client/src/components/CustomDropdown/index.ts
@@ -1,0 +1,3 @@
+import CustomDropdown from './CustomDropdown';
+
+export default CustomDropdown;

--- a/client/src/components/Input/Input.jsx
+++ b/client/src/components/Input/Input.jsx
@@ -42,6 +42,7 @@ const Input = props => {
     lowerCased = false,
     disabled,
     showErrorBorder,
+    isLowHeight,
     ...rest
   } = props;
   const {
@@ -160,6 +161,7 @@ const Input = props => {
             prefix && classes.prefixSpace,
             showCopyButton && classes.hasCopyButton,
             type === 'password' && classes.doubleIconInput,
+            isLowHeight && classes.lowHeight,
           )}
         >
           {renderPrefixLabel()}
@@ -177,7 +179,7 @@ const Input = props => {
             data-clear={clearInput}
           />
         </div>
-        {(clearInput || onClose) && !loading && (
+        {(clearInput || onClose) && !disabled && !loading && (
           <FontAwesomeIcon
             icon="times-circle"
             className={classnames(
@@ -185,6 +187,7 @@ const Input = props => {
               type === 'password' && classes.doubleIcon,
               isBW && classes.bw,
               disabled && classes.disabled,
+              uiType && classes[uiType],
             )}
             onClick={() => {
               if (disabled) return;
@@ -205,7 +208,7 @@ const Input = props => {
             onClick={() => !disabled && toggleShowPass(!showPass)}
           />
         )}
-        {showCopyButton && (
+        {showCopyButton && !value && (
           <CopyButton
             onClick={async () => {
               try {

--- a/client/src/components/Input/Input.module.scss
+++ b/client/src/components/Input/Input.module.scss
@@ -53,7 +53,7 @@
     width: 20px !important;
     height: 20px;
 
-    &.bw {
+    &.bw, &.blackWhite {
       color: $dark-gray;
     }
 
@@ -163,6 +163,10 @@
 
      &.error {
       border-color: $warn-red;
+    }
+
+    &.lowHeight {
+      height: 40px;
     }
 
     &.blackLight, &.blackWhite {

--- a/client/src/components/SignNft/SignNft.tsx
+++ b/client/src/components/SignNft/SignNft.tsx
@@ -34,7 +34,7 @@ const SignNft: React.FC<ContainerProps> = props => {
     result,
     isEdit,
     refreshFioNames,
-    getSignaturesFromFioAddress,
+    getNFTSignatures,
   } = props;
   const history = useHistory();
   const [processing, setProcessing] = useState(false);
@@ -106,7 +106,7 @@ const SignNft: React.FC<ContainerProps> = props => {
         });
 
         refreshFioNames(fioAddress.walletPublicKey);
-        getSignaturesFromFioAddress(fioAddress.name);
+        getNFTSignatures({ fioAddress: fioAddress.name });
       }
       setProcessing(false);
     }

--- a/client/src/components/SignNft/index.tsx
+++ b/client/src/components/SignNft/index.tsx
@@ -15,7 +15,7 @@ import {
   getFee,
   FIO_SIGN_NFT_REQUEST,
   refreshFioNames,
-  getSignaturesFromFioAddress,
+  getNFTSignatures,
 } from '../../redux/fio/actions';
 import { showPinModal } from '../../redux/modal/actions';
 import { resetPinConfirm } from '../../redux/edge/actions';
@@ -60,7 +60,7 @@ const reduxConnect = connect(
       getFee(apis.fio.actionEndPoints.signNft, fioAddress),
     singNFT,
     refreshFioNames,
-    getSignaturesFromFioAddress,
+    getNFTSignatures,
   },
 );
 

--- a/client/src/components/SignNft/types.d.ts
+++ b/client/src/components/SignNft/types.d.ts
@@ -50,7 +50,7 @@ export type ContainerProps = {
   resetPinConfirm: () => void;
   pinConfirmation: PinConfirmation;
   refreshFioNames: (publicKey: string) => void;
-  getSignaturesFromFioAddress: (fioAddress: string) => void;
+  getNFTSignatures: (searchParams: { fioAddress: string }) => void;
 } & ContainerOwnProps;
 
 export type SignNftFormProps = {

--- a/client/src/constants/routes.ts
+++ b/client/src/constants/routes.ts
@@ -44,6 +44,7 @@ const ROUTES: { [route: string]: string } = {
   DELETE_TOKEN: '/delete-token',
   SETTINGS: '/settings',
   ACCOUNT_RECOVERY: '/account-recovery',
+  NFT_VALIDATION: '/nft-validation',
 
   // Referrer Profile pages
   REF_PROFILE_HOME: '/ref/:refProfileCode',

--- a/client/src/pages/FioAddressSignaturesPage/FioAddressSignaturesPage.tsx
+++ b/client/src/pages/FioAddressSignaturesPage/FioAddressSignaturesPage.tsx
@@ -18,7 +18,7 @@ import { NFTTokenDoublet } from '../../types';
 import classes from './FioAddressSignaturesPage.module.scss';
 
 type Props = {
-  getSignaturesFromFioAddress: (fioAddress: string) => void;
+  getNFTSignatures: (searchParams: { fioAddress: string }) => void;
   nftSignatures: NFTTokenDoublet[];
   loading: boolean;
   match: {
@@ -29,15 +29,15 @@ type Props = {
 const FioAddressSignaturesPage: React.FC<Props> = props => {
   const {
     nftSignatures,
-    getSignaturesFromFioAddress,
+    getNFTSignatures,
     loading,
     match: {
       params: { address },
     },
   } = props;
   useEffect(() => {
-    getSignaturesFromFioAddress(address);
-  }, [getSignaturesFromFioAddress]);
+    getNFTSignatures({ fioAddress: address });
+  }, [getNFTSignatures]);
 
   return (
     <PseudoModalContainer

--- a/client/src/pages/FioAddressSignaturesPage/index.tsx
+++ b/client/src/pages/FioAddressSignaturesPage/index.tsx
@@ -3,7 +3,7 @@ import { createStructuredSelector } from 'reselect';
 import { compose } from '../../utils';
 import FioAddressSignaturesPage from './FioAddressSignaturesPage';
 import { withRouter } from 'react-router-dom';
-import { getSignaturesFromFioAddress } from '../../redux/fio/actions';
+import { getNFTSignatures } from '../../redux/fio/actions';
 import { nftSignatures, loading } from '../../redux/fio/selectors';
 
 const reduxConnect = connect(
@@ -12,7 +12,7 @@ const reduxConnect = connect(
     loading,
   }),
   {
-    getSignaturesFromFioAddress,
+    getNFTSignatures,
   },
 );
 

--- a/client/src/pages/NftValidationPage/NftValidationPage.module.scss
+++ b/client/src/pages/NftValidationPage/NftValidationPage.module.scss
@@ -1,0 +1,67 @@
+@import '../../assets/styles/colors.scss';
+@import '../../assets/styles/mediaQueriesMixings.scss';
+@import '../../assets/styles/fontMixins.scss';
+
+.container {
+  background: $footer-background;
+  width: 100%;
+  text-align: center;
+  color: $white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-bottom: 117px;
+
+  .title {
+    font-size: 4em;
+    color: $white;
+    margin-top: 7.125rem;
+    margin-bottom: 0;
+  }
+  .subtitle {
+    max-width: 795px;
+    width: 100%;
+    margin-top: 1.25rem;
+    margin-bottom: 0;
+    @include proxima-nova-thin;
+    text-align: center;
+  }
+  .cta {
+    margin-top: 1.875rem;
+    margin-bottom: 0;
+    font-size: 1.125em;
+    @include proxima-nova-semibold;
+  }
+  .dropdownContainer {
+    margin-top: 25px;
+  }
+  .maxField {
+    min-width: 335px;
+    width: 100%;
+  }
+  .maxField {
+    margin: 0 20px;
+  }
+  .formContainer {
+    width: 100%;
+    max-width: 969px;
+  }
+
+  .badgeContainer {
+    margin-top: 60px;
+  }
+}
+
+@include sm {
+  .container {
+    .title {
+      margin-top: 3.5rem;
+      font-size: 2.125em;
+    }
+    .subtitle {
+      font-size: 1em;
+      width: 90%;
+    }
+
+  }
+}

--- a/client/src/pages/NftValidationPage/NftValidationPage.tsx
+++ b/client/src/pages/NftValidationPage/NftValidationPage.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import apis from '../../api/index';
+
+import InfoBadge from '../../components/Badges/InfoBadge/InfoBadge';
+import NftValidationForm from './components/NftValidationForm';
+import CustomDropdown from '../../components/CustomDropdown';
+
+import NftListResults from './components/NftListResults';
+import { OPTIONS, optionsList } from './constant';
+import { transformNft } from '../../util/fio';
+import { minWaitTimeFunction } from '../../utils';
+
+import { NftValidationFormValues, ValidationOption } from './components/types';
+
+import classes from './NftValidationPage.module.scss';
+
+const NftValidationPage: React.FC = () => {
+  const [activeOption, setActiveOption] = useState<ValidationOption | null>(
+    null,
+  );
+  const [
+    searchParams,
+    setSearchParams,
+  ] = useState<NftValidationFormValues | null>(null);
+  const [results, setResults] = useState(null);
+  const [loading, toggleLoading] = useState(false);
+
+  const onDropDownChange = (id: string) => {
+    setActiveOption(OPTIONS[id]);
+    setSearchParams(null);
+    setResults(null);
+  };
+
+  const onSubmit = async (values: NftValidationFormValues) => {
+    toggleLoading(true);
+    setResults(null);
+    setSearchParams(values);
+    const nftResults = await minWaitTimeFunction(
+      () => apis.fio.getNFTs(values),
+      2000,
+    );
+    if (nftResults) setResults(transformNft(nftResults.nfts));
+    toggleLoading(false);
+  };
+
+  const showInfoBadge =
+    searchParams != null && results != null && results.length === 0 && !loading;
+
+  return (
+    <div className={classes.container}>
+      <h1 className={classes.title}>
+        <span className="doubleColor boldText">Validate a</span> NFT Signature
+      </h1>
+      <h3 className={classes.subtitle}>
+        You can easily validate a NFT signature through with NFT details, FIO
+        address, image or hash/media URL.
+      </h3>
+      <p className={classes.cta}>
+        How would you like to validate the NFT Signature?
+      </p>
+      <div className={classes.dropdownContainer}>
+        <CustomDropdown
+          options={optionsList}
+          onChange={onDropDownChange}
+          placeholder="Select Your Validation Method"
+        />
+      </div>
+      {activeOption != null && (
+        <div className={classes.formContainer}>
+          <NftValidationForm
+            activeOption={activeOption}
+            onSubmit={onSubmit}
+            loading={loading}
+          />
+        </div>
+      )}
+      <NftListResults
+        searchParams={searchParams}
+        activeOption={activeOption}
+        results={results}
+      />
+      {showInfoBadge && (
+        <div className={classes.badgeContainer}>
+          <InfoBadge
+            title="No NFT Signatures"
+            message={`There are no NFT signatures for this ${activeOption.name}`}
+            isOrange={true}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NftValidationPage;

--- a/client/src/pages/NftValidationPage/components/ContractAddressField.tsx
+++ b/client/src/pages/NftValidationPage/components/ContractAddressField.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import GenericNftValidationField, {
+  FIELDS_NAMES,
+} from './GenericNftValidationField';
+
+import classes from './GenericNftValidationField.module.scss';
+
+const ContractAddressField: React.FC = () => {
+  return (
+    <div className={classes.contractAddressContainer}>
+      <GenericNftValidationField fieldName={FIELDS_NAMES.CHAIN_CODE} />
+      <GenericNftValidationField
+        fieldName={FIELDS_NAMES.CONTRACT_ADDRESS}
+        isMaxField={true}
+      />
+      <GenericNftValidationField fieldName={FIELDS_NAMES.TOKEN_ID} />
+    </div>
+  );
+};
+
+export default ContractAddressField;

--- a/client/src/pages/NftValidationPage/components/GenericNftValidationField.module.scss
+++ b/client/src/pages/NftValidationPage/components/GenericNftValidationField.module.scss
@@ -1,0 +1,28 @@
+@import '../../../assets/styles/mediaQueriesMixings.scss';
+
+.contractAddressContainer {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.smallField {
+  min-width: 235px;
+  width: 100%;
+}
+.maxField {
+  min-width: 295px;
+  width: 100%;
+  max-width: 335px;
+  flex-shrink: 0;
+}
+
+
+@include lg {
+  .contractAddressContainer {
+    flex-direction: row;
+  }
+  .maxField {
+    margin: 0 20px;
+  }
+}

--- a/client/src/pages/NftValidationPage/components/GenericNftValidationField.tsx
+++ b/client/src/pages/NftValidationPage/components/GenericNftValidationField.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Field } from 'react-final-form';
+import Input, { INPUT_UI_STYLES } from '../../../components/Input/Input';
+
+import classes from './GenericNftValidationField.module.scss';
+
+export const FIELDS_NAMES = {
+  FIO_ADDRESS: 'fioAddress',
+  HASH: 'hash',
+  CHAIN_CODE: 'chainCode',
+  CONTRACT_ADDRESS: 'contractAddress',
+  TOKEN_ID: 'tokenId',
+};
+
+const FIELDS_PLACEHOLDER = {
+  [FIELDS_NAMES.FIO_ADDRESS]: 'Enter or Paste FIO Address',
+  [FIELDS_NAMES.HASH]: 'Enter or Paste Hash',
+  [FIELDS_NAMES.CHAIN_CODE]: 'Enter or Paste Chain Code',
+  [FIELDS_NAMES.CONTRACT_ADDRESS]: 'Enter or Paste Contract Address',
+  [FIELDS_NAMES.TOKEN_ID]: 'Enter or Paste Token ID',
+};
+
+type Props = {
+  fieldName: string;
+  isMaxField?: boolean;
+};
+
+const GenericNftValidationField: React.FC<Props> = props => {
+  const { fieldName, isMaxField } = props;
+  return (
+    <div className={isMaxField ? classes.maxField : classes.smallField}>
+      <Field
+        type="text"
+        name={fieldName}
+        placeholder={FIELDS_PLACEHOLDER[fieldName]}
+        component={Input}
+        uiType={INPUT_UI_STYLES.BLACK_WHITE}
+        showCopyButton={true}
+        isLowHeight={true}
+      />
+    </div>
+  );
+};
+
+export default GenericNftValidationField;

--- a/client/src/pages/NftValidationPage/components/NftItemResult/GenericNftItemResult.module.scss
+++ b/client/src/pages/NftValidationPage/components/NftItemResult/GenericNftItemResult.module.scss
@@ -1,0 +1,58 @@
+@import '../../../../assets/styles/colors.scss';
+@import '../../../../assets/styles/mediaQueriesMixings.scss';
+@import '../../../../assets/styles/fontMixins.scss';
+
+.container {
+  cursor: pointer;
+
+  .badgeContainer {
+    color: $dark-jungle-green;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+
+    .resultsContainer {
+      display: flex;
+      flex-direction: column;
+
+      .titleContainer {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        margin-right: 15px;
+        margin-top: 20px;
+
+        &:first-of-type {
+          margin-top: 0;
+        }
+
+        .title {
+          margin-right: 10px;
+        }
+        .resultValue {
+          word-break: break-all;
+          text-align: left;
+          @include proxima-nova-bold;
+        }
+      }
+    }
+  }
+  .actionIcon {
+    margin-left: auto;
+  }
+}
+
+@include lg {
+  .container {
+    .badgeContainer {
+      .resultsContainer {
+        flex-direction: row;
+        .titleContainer {
+          flex-direction: row;
+          margin-top: 0;
+        }
+      }
+    }
+  }
+}

--- a/client/src/pages/NftValidationPage/components/NftItemResult/GenericNftItemResult.tsx
+++ b/client/src/pages/NftValidationPage/components/NftItemResult/GenericNftItemResult.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Badge, { BADGE_TYPES } from '../../../../components/Badge/Badge';
+import NftValidationItemModal from '../NftValidationItemModal';
+
+import { NFTTokenDoublet, CommonObjectProps } from '../../../../types';
+import { NftValidationFormValues, RenderItem } from '../types';
+
+import classes from './GenericNftItemResult.module.scss';
+import { TITLE_NAME } from '../../constant';
+
+type Props = {
+  titles: { name: string; id: string }[];
+  resultItem: NFTTokenDoublet;
+  searchParams: NftValidationFormValues;
+};
+
+const GenericNftItemResult: React.FC<Props> = props => {
+  const { titles, resultItem, searchParams } = props;
+  const [showModal, toggleModal] = useState(false);
+
+  const openModal = () => toggleModal(true);
+  const closeModal = () => toggleModal(false);
+
+  return (
+    <>
+      <div className={classes.container} onClick={openModal}>
+        <Badge show={true} type={BADGE_TYPES.WHITE}>
+          <div className={classes.badgeContainer}>
+            <div className={classes.resultsContainer}>
+              {titles.map(title => {
+                const resultValue: CommonObjectProps = { ...resultItem };
+                return (
+                  <div className={classes.titleContainer} key={title.id}>
+                    <div className={classes.title}>{title.name}:</div>
+                    <div className={classes.resultValue}>
+                      {resultValue[title.id] || '-'}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <FontAwesomeIcon
+              icon="chevron-right"
+              className={classes.actionIcon}
+            />
+          </div>
+        </Badge>
+      </div>
+      <NftValidationItemModal
+        show={showModal}
+        resultItem={resultItem}
+        onClose={closeModal}
+        searchParams={searchParams}
+      />
+    </>
+  );
+};
+
+export default GenericNftItemResult;
+
+export const renderContractAddressItem: RenderItem = (
+  resultItem,
+  searchParams,
+) => (
+  <GenericNftItemResult
+    titles={[TITLE_NAME.fioAddress]}
+    resultItem={resultItem}
+    searchParams={searchParams}
+  />
+);

--- a/client/src/pages/NftValidationPage/components/NftListResults.module.scss
+++ b/client/src/pages/NftValidationPage/components/NftListResults.module.scss
@@ -1,0 +1,24 @@
+@import '../../../assets/styles/colors.scss';
+@import '../../../assets/styles/fontMixins.scss';
+@import '../../../assets/styles/mediaQueriesMixings.scss';
+
+.container {
+  width: 100%;
+  max-width: 969px;
+  padding: 0 20px;
+  .title {
+    margin-top: 50px;
+  }
+  .resultsContainer {
+    margin-top: 40px;
+    background-color: $aqua-haze;
+    padding: 34px 30px 30px;
+    border-radius: 12px;
+    color: $dark-jungle-green;
+
+    .resultsTitle {
+      text-align: left;
+      margin-bottom: 15px;
+    }
+  }
+}

--- a/client/src/pages/NftValidationPage/components/NftListResults.tsx
+++ b/client/src/pages/NftValidationPage/components/NftListResults.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { nftId } from '../../../util/nft';
+import classes from './NftListResults.module.scss';
+
+import { NftValidationFormValues, ValidationOption } from './types';
+import { NFTTokenDoublet } from '../../../types';
+
+type Props = {
+  activeOption?: ValidationOption;
+  searchParams?: NftValidationFormValues;
+  results: NFTTokenDoublet[];
+};
+
+const NftListResults: React.FC<Props> = props => {
+  const { activeOption, searchParams, results } = props;
+  if (
+    activeOption != null &&
+    searchParams != null &&
+    results != null &&
+    results.length > 0
+  )
+    return (
+      <div className={classes.container}>
+        <h3 className={classes.title}>NFT Signature Information</h3>
+        <div className={classes.resultsContainer}>
+          <h3 className={classes.resultsTitle}>Results</h3>
+          {activeOption.resultsTitle(searchParams)}
+          {results.map(item => (
+            <div
+              key={nftId(item.chainCode, item.tokenId, item.contractAddress)}
+            >
+              {activeOption.resultsItem(item, searchParams)}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  return null;
+};
+
+export default NftListResults;

--- a/client/src/pages/NftValidationPage/components/NftListTitle/ContractAddressTitle.module.scss
+++ b/client/src/pages/NftValidationPage/components/NftListTitle/ContractAddressTitle.module.scss
@@ -1,0 +1,24 @@
+@import '../../../../assets/styles/mediaQueriesMixings.scss';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  &:first-child {
+    margin-left: 0;
+  }
+  .titleItem {
+    margin-left: 0px;
+  }
+}
+
+@include lg {
+  .container {
+    flex-direction: row;
+    .titleItem {
+      margin-left: 20px;
+      &:first-of-type {
+        margin-left: 0;
+      }
+    }
+  }
+}

--- a/client/src/pages/NftValidationPage/components/NftListTitle/ContractAddressTitle.tsx
+++ b/client/src/pages/NftValidationPage/components/NftListTitle/ContractAddressTitle.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import GenericTitleComponent from './GenericTitleComponent';
+
+import { TITLE_NAME } from '../../constant';
+import classes from './ContractAddressTitle.module.scss';
+import { RenderTitle } from '../types';
+
+type Props = {
+  values: { chainCode?: string; contractAddress?: string; tokenId?: string };
+};
+
+const ContractAddressTitle: React.FC<Props> = props => {
+  const {
+    values: { chainCode, contractAddress, tokenId },
+  } = props;
+  return (
+    <div className={classes.container}>
+      <div className={classes.titleItem}>
+        <GenericTitleComponent
+          title={TITLE_NAME.chainCode.name}
+          value={chainCode}
+        />
+      </div>
+      <div className={classes.titleItem}>
+        <GenericTitleComponent
+          title={TITLE_NAME.contractAddress.name}
+          value={contractAddress}
+        />
+      </div>
+      <div className={classes.titleItem}>
+        <GenericTitleComponent
+          title={TITLE_NAME.tokenId.name}
+          value={tokenId}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ContractAddressTitle;
+
+export const renderContractAddressTitle: RenderTitle = searchParams => (
+  <ContractAddressTitle values={searchParams} />
+);

--- a/client/src/pages/NftValidationPage/components/NftListTitle/GenericTitleComponent.module.scss
+++ b/client/src/pages/NftValidationPage/components/NftListTitle/GenericTitleComponent.module.scss
@@ -1,0 +1,42 @@
+@import '../../../../assets/styles/colors.scss';
+@import '../../../../assets/styles/fontMixins.scss';
+@import '../../../../assets/styles/mediaQueriesMixings.scss';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  .title, .value {
+    font-size: 0.9375em;
+    margin-bottom: 0;
+  }
+
+  .title {
+    @include proxima-nova-thin;
+    margin-top: 20px;
+  }
+
+  .value {
+    @include proxima-nova-bold;
+    margin-top: 10px;
+    word-break: break-all;
+    text-align: left;
+  }
+}
+
+@include lg {
+  .container {
+    flex-direction: row;
+    align-items: center;
+
+    .title, .value {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+
+    .value {
+      margin-left: 10px;
+    }
+  }
+}

--- a/client/src/pages/NftValidationPage/components/NftListTitle/GenericTitleComponent.tsx
+++ b/client/src/pages/NftValidationPage/components/NftListTitle/GenericTitleComponent.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import classes from './GenericTitleComponent.module.scss';
+
+type Props = {
+  title: string;
+  value: string;
+};
+
+const GenericTitleComponent: React.FC<Props> = props => {
+  const { title, value } = props;
+  return (
+    <div className={classes.container}>
+      <h5 className={classes.title}>{title}:</h5>
+      <p className={classes.value}>{value || '-'}</p>
+    </div>
+  );
+};
+
+export default GenericTitleComponent;

--- a/client/src/pages/NftValidationPage/components/NftValidationForm.module.scss
+++ b/client/src/pages/NftValidationPage/components/NftValidationForm.module.scss
@@ -1,0 +1,30 @@
+@import '../../../assets/styles/mediaQueriesMixings.scss';
+
+.form {
+  padding: 0 20px;
+
+  .submitButton {
+    max-width: 235px;
+    width: 100%;
+    height: 40px;
+    font-size: 0.8125em;
+    border-radius: 7px;
+    margin-bottom: 0;
+    position: relative;
+    @include sm {
+      max-width: none;
+    }
+
+    .loader {
+      font-size: 1.2em;
+      position: absolute;
+      right: 25px;
+    }
+  }
+}
+
+@include lg {
+  .form {
+    padding: 0;
+  }
+}

--- a/client/src/pages/NftValidationPage/components/NftValidationForm.tsx
+++ b/client/src/pages/NftValidationPage/components/NftValidationForm.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect } from 'react';
+import { Form, FormProps, FormRenderProps } from 'react-final-form';
+import { Button } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import apis from '../../../api';
+import { NftValidationFormValues, ValidationOption } from './types';
+import { OPTIONS } from '../constant';
+
+import classes from './NftValidationForm.module.scss';
+
+type Props = {
+  activeOption: ValidationOption;
+  loading: boolean;
+};
+
+const validate = (
+  values: NftValidationFormValues,
+  activeOption: ValidationOption,
+) => {
+  const errors: NftValidationFormValues = {};
+  if (activeOption.id === OPTIONS.contractAddress.id) {
+    if (!values.chainCode) errors.chainCode = 'Required';
+    if (!values.contractAddress) errors.contractAddress = 'Required';
+  }
+  if (activeOption.id === OPTIONS.fioAddress.id) {
+    if (!values.fioAddress) {
+      errors.fioAddress = 'Required';
+    } else {
+      try {
+        apis.fio.isFioAddressValid(values.fioAddress);
+      } catch (e) {
+        errors.fioAddress = 'FIO Address is not valid';
+      }
+    }
+  }
+  if (activeOption.id === OPTIONS.hash.id) {
+    if (!values.hash) errors.hash = 'Required';
+  }
+
+  return errors;
+};
+
+const RenderForm: React.FC<Props & FormRenderProps> = props => {
+  const { handleSubmit, form, activeOption, loading, valid } = props;
+  const { name, field } = activeOption || {};
+  useEffect(() => {
+    name && form.reset();
+  }, [name]);
+
+  return (
+    <form onSubmit={handleSubmit} className={classes.form}>
+      {field}
+      <Button
+        type="submit"
+        className={classes.submitButton}
+        disabled={loading || !valid}
+      >
+        Validate NFT Signature{' '}
+        {loading && (
+          <FontAwesomeIcon spin icon="spinner" className={classes.loader} />
+        )}
+      </Button>
+    </form>
+  );
+};
+
+const NftValidationForm: React.FC<Props & FormProps> = props => {
+  const { onSubmit, activeOption } = props;
+
+  return (
+    <Form
+      onSubmit={onSubmit}
+      validate={values => validate(values, activeOption)}
+      render={formProps => <RenderForm {...props} {...formProps} />}
+    ></Form>
+  );
+};
+
+export default NftValidationForm;

--- a/client/src/pages/NftValidationPage/components/NftValidationItemModal.module.scss
+++ b/client/src/pages/NftValidationPage/components/NftValidationItemModal.module.scss
@@ -1,0 +1,93 @@
+@import '../../../assets/styles/mediaQueriesMixings.scss';
+@import '../../../assets/styles/fontMixins.scss';
+@import '../../../assets/styles/colors.scss';
+
+.container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  @include proxima-nova-bold;
+
+  .title {
+    font-size: 1.75em;
+  }
+  .subtitleContainer {
+    display: flex;
+    flex-direction: column;
+    .subtitle {
+      font-size: 1em;
+      margin-top: 20px;
+      margin-bottom: 0;
+    }
+    .searchParam {
+      margin-top: 5px;
+      word-break: break-all;
+      font-size: 1em;
+      margin-bottom: 0;
+    }
+  }
+  .itemContainer {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+
+    .badgeContainer {
+      flex-basis: 100%;
+      .contentContainer {
+        color: $dark-jungle-green;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+
+        .contentTitle {
+          font-size: 1em;
+          margin-top: 0;
+          margin-bottom: 0;
+        }
+        .contentValue {
+          font-size: 1em;
+          margin-top: 10px;
+          margin-bottom: 0;
+          margin-left: 0;
+          word-break: break-all;
+        }
+      }
+      &.isSmall {
+        flex-basis: 100%;
+      }
+    }
+
+  }
+
+  .button {
+    width: 100%;
+    max-width: 335px;
+    height: 54px;
+    border-radius: 7px;
+    margin-top: 30px;
+    margin-bottom: 20px;
+    align-self: center;
+  }
+}
+
+@include lg {
+  .container {
+    padding: 0 20px;
+    .itemContainer {
+      .badgeContainer {
+        .contentContainer {
+          flex-direction: row;
+          align-items: center;
+          .contentValue {
+            margin-left: 30px;
+            margin-top: 0;
+          }
+        }
+        &.isSmall {
+          flex-basis: 47%;
+        }
+      }
+    }
+  }
+}

--- a/client/src/pages/NftValidationPage/components/NftValidationItemModal.tsx
+++ b/client/src/pages/NftValidationPage/components/NftValidationItemModal.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { Button } from 'react-bootstrap';
+import classnames from 'classnames';
+
+import Modal from '../../../components/Modal/Modal';
+import Badge, { BADGE_TYPES } from '../../../components/Badge/Badge';
+import { TITLE_NAME } from '../constant';
+
+import { NFTTokenDoublet, CommonObjectProps } from '../../../types';
+import { NftValidationFormValues } from './types';
+
+import classes from './NftValidationItemModal.module.scss';
+
+type Props = {
+  show: boolean;
+  resultItem: NFTTokenDoublet;
+  onClose: () => void;
+  searchParams: NftValidationFormValues;
+};
+
+const NftValidationItemModal: React.FC<Props> = props => {
+  const { show, onClose, resultItem, searchParams } = props;
+
+  const searchParamObj: CommonObjectProps =
+    (searchParams != null && { ...searchParams }) || {};
+  delete searchParamObj.chainCode;
+  delete searchParamObj.tokenId;
+
+  const titleObj = Object.keys(searchParamObj)[0];
+
+  const resultItemToRender: CommonObjectProps = { ...resultItem };
+  delete resultItemToRender[titleObj];
+
+  const renderBadge = () => {
+    const itemValues: {
+      title: string;
+      value: string;
+      isSmall?: boolean;
+    }[] = Object.keys(resultItemToRender).map(key => {
+      const objValue = resultItemToRender[key];
+      if (key === 'metadata') {
+        const creatorUrl = (() => {
+          try {
+            return JSON.parse(objValue).creator_url;
+          } catch (err) {
+            return '';
+          }
+        })();
+        return { title: 'Creator URL', value: creatorUrl };
+      }
+      if (key === TITLE_NAME.chainCode.id || key === TITLE_NAME.tokenId.id) {
+        return {
+          title: TITLE_NAME[key].name,
+          value: objValue,
+          isSmall: true,
+        };
+      }
+      return {
+        title: TITLE_NAME[key].name,
+        value: objValue,
+      };
+    });
+
+    return itemValues.map(item => {
+      const { title, value, isSmall } = item;
+      return (
+        <div
+          key={title + value}
+          className={classnames(
+            classes.badgeContainer,
+            isSmall && classes.isSmall,
+          )}
+        >
+          <Badge show={true} type={BADGE_TYPES.WHITE}>
+            <div className={classes.contentContainer}>
+              <h5 className={classes.contentTitle}>{title}</h5>
+              <p className={classes.contentValue}>{value || '-'}</p>
+            </div>
+          </Badge>
+        </div>
+      );
+    });
+  };
+
+  return (
+    <Modal
+      show={show}
+      closeButton={true}
+      onClose={onClose}
+      isSimple={true}
+      isWide={true}
+    >
+      <div className={classes.container}>
+        <h3 className={classes.title}>NFT Signature Information</h3>
+        <div className={classes.subtitleContainer}>
+          <h5 className={classes.subtitle}>{TITLE_NAME[titleObj].name}</h5>
+          <p className={classes.searchParam}>{searchParamObj[titleObj]}</p>
+        </div>
+        <div className={classes.itemContainer}>{renderBadge()}</div>
+        <Button onClick={onClose} className={classes.button}>
+          Close
+        </Button>
+      </div>
+    </Modal>
+  );
+};
+
+export default NftValidationItemModal;

--- a/client/src/pages/NftValidationPage/components/types.d.ts
+++ b/client/src/pages/NftValidationPage/components/types.d.ts
@@ -1,0 +1,27 @@
+import React from 'react';
+import { NFTTokenDoublet } from '../../../types';
+
+export type NftValidationFormValues = {
+  contractAddress?: string;
+  tokenId?: string;
+  hash?: string;
+  fioAddress?: string;
+  chainCode?: string;
+};
+
+export type RenderTitle = (
+  searchParams: NftValidationFormValues,
+) => React.ReactNode;
+
+export type RenderItem = (
+  resultItem: NFTTokenDoublet,
+  searchParams: NftValidationFormValues,
+) => React.ReactNode;
+
+export type ValidationOption = {
+  id: string;
+  name: string;
+  field: React.ReactNode;
+  resultsTitle: RenderTitle;
+  resultsItem: RenderItem;
+};

--- a/client/src/pages/NftValidationPage/constant.tsx
+++ b/client/src/pages/NftValidationPage/constant.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+
+import ContractAddressField from './components/ContractAddressField';
+import GenericNftValidationField, {
+  FIELDS_NAMES,
+} from './components/GenericNftValidationField';
+import { renderContractAddressTitle } from './components/NftListTitle/ContractAddressTitle';
+import GenericTitleComponent from './components/NftListTitle/GenericTitleComponent';
+import GenericNftItemResult, {
+  renderContractAddressItem,
+} from './components/NftItemResult/GenericNftItemResult';
+
+import { RenderItem, RenderTitle, ValidationOption } from './components/types';
+
+export const TITLE_NAME: { [key: string]: { id: string; name: string } } = {
+  contractAddress: {
+    name: 'Contract Address',
+    id: 'contractAddress',
+  },
+  chainCode: {
+    name: 'Chain Code',
+    id: 'chainCode',
+  },
+  tokenId: {
+    name: 'Token ID',
+    id: 'tokenId',
+  },
+  fioAddress: {
+    name: 'FIO Address',
+    id: 'fioAddress',
+  },
+  url: {
+    name: 'URL',
+    id: 'url',
+  },
+  hash: {
+    name: 'Hash',
+    id: 'hash',
+  },
+};
+
+const renderFioAddressTitle: RenderTitle = searchParams => (
+  <GenericTitleComponent title="FIO Address" value={searchParams.fioAddress} />
+);
+
+const renderFioAddressItem: RenderItem = (resultItem, searchParams) => (
+  <GenericNftItemResult
+    titles={[TITLE_NAME.chainCode, TITLE_NAME.tokenId]}
+    resultItem={resultItem}
+    searchParams={searchParams}
+  />
+);
+
+const renderHashTitle: RenderTitle = values => (
+  <GenericTitleComponent title="Hash" value={values.hash} />
+);
+
+const renderHashItem: RenderItem = (resultItem, searchParams) => (
+  <GenericNftItemResult
+    titles={[
+      TITLE_NAME.fioAddress,
+      TITLE_NAME.chainCode,
+      TITLE_NAME.contractAddress,
+    ]}
+    resultItem={resultItem}
+    searchParams={searchParams}
+  />
+);
+
+export const OPTIONS: {
+  [key: string]: ValidationOption;
+} = {
+  contractAddress: {
+    id: TITLE_NAME.contractAddress.id,
+    name: TITLE_NAME.contractAddress.name,
+    field: <ContractAddressField />,
+    resultsTitle: renderContractAddressTitle,
+    resultsItem: renderContractAddressItem,
+  },
+  fioAddress: {
+    id: TITLE_NAME.fioAddress.id,
+    name: TITLE_NAME.fioAddress.name,
+    field: (
+      <GenericNftValidationField
+        fieldName={FIELDS_NAMES.FIO_ADDRESS}
+        isMaxField={true}
+      />
+    ),
+    resultsTitle: renderFioAddressTitle,
+    resultsItem: renderFioAddressItem,
+  },
+  hash: {
+    id: TITLE_NAME.hash.id,
+    name: TITLE_NAME.hash.name,
+    field: (
+      <GenericNftValidationField
+        fieldName={FIELDS_NAMES.HASH}
+        isMaxField={true}
+      />
+    ),
+    resultsTitle: renderHashTitle,
+    resultsItem: renderHashItem,
+  },
+  //image: {
+  //   id: 'image',
+  //   name: 'Image',
+  //   field: <div>Image</div>,
+  //   resultsTitle: (values: any) => <div></div>,
+  //   resultsItem: (resultItem: NFTTokenDoublet) => <div></div>,
+  // }, // todo: set image upload hash method
+};
+
+export const optionsList = Object.values(OPTIONS).map(({ id, name }) => ({
+  id,
+  name,
+}));

--- a/client/src/pages/NftValidationPage/index.ts
+++ b/client/src/pages/NftValidationPage/index.ts
@@ -1,0 +1,3 @@
+import NftValidationPage from './NftValidationPage';
+
+export default NftValidationPage;

--- a/client/src/redux/fio/actions.ts
+++ b/client/src/redux/fio/actions.ts
@@ -378,23 +378,31 @@ export const linkTokens = ({
   actionName: LINK_TOKENS_REQUEST,
 });
 
-export const FIO_SIGNATURE_ADDRESS_REQUEST = `${prefix}/FIO_SIGNATURE_ADDRESS_REQUEST`;
-export const FIO_SIGNATURE_ADDRESS_SUCCESS = `${prefix}/FIO_SIGNATURE_ADDRESS_SUCCESS`;
-export const FIO_SIGNATURE_ADDRESS_FAILURE = `${prefix}/FIO_SIGNATURE_ADDRESS_FAILURE`;
+export const FIO_SIGNATURE_REQUEST = `${prefix}/FIO_SIGNATURE_REQUEST`;
+export const FIO_SIGNATURE_SUCCESS = `${prefix}/FIO_SIGNATURE_SUCCESS`;
+export const FIO_SIGNATURE_FAILURE = `${prefix}/FIO_SIGNATURE_FAILURE`;
 export const FIO_SIGN_NFT_REQUEST = `${prefix}/FIO_SIGN_NFT_REQUEST`;
 export const FIO_SIGN_NFT_SUCCESS = `${prefix}/FIO_SIGN_NFT_SUCCESS`;
 export const FIO_SIGN_NFT_FAILURE = `${prefix}/FIO_SIGN_NFT_FAILURE`;
 
-export const getSignaturesFromFioAddress = (fioAddress: string) => ({
-  types: [
-    FIO_SIGNATURE_ADDRESS_REQUEST,
-    FIO_SIGNATURE_ADDRESS_SUCCESS,
-    FIO_SIGNATURE_ADDRESS_FAILURE,
-  ],
+export const getNFTSignatures = (searchParams: {
+  fioAddress?: string;
+  chainCode?: string;
+  hash?: string;
+  tokenId?: string;
+  contractAddress?: string;
+}) => ({
+  types: [FIO_SIGNATURE_REQUEST, FIO_SIGNATURE_SUCCESS, FIO_SIGNATURE_FAILURE],
   promise: (api: Api) => {
-    return api.fio.getNFTsFioAddress(fioAddress);
+    return api.fio.getNFTs(searchParams);
   },
-  fioAddress,
+  searchParams,
+});
+
+export const CLEAR_NFT_SIGNATURES = `${prefix}/CLEAR_NFT_SIGNATURES`;
+
+export const clearNFTSignatures = () => ({
+  type: CLEAR_NFT_SIGNATURES,
 });
 
 export const singNFT = (

--- a/client/src/redux/fio/reducer.ts
+++ b/client/src/redux/fio/reducer.ts
@@ -14,6 +14,8 @@ import {
   NFTTokenDoublet,
 } from '../../types';
 
+import { transformNft } from '../../util/fio';
+
 export const emptyWallet: FioWalletDoublet = {
   id: '',
   name: '',
@@ -32,7 +34,7 @@ export default combineReducers({
       case actions.REFRESH_BALANCE_REQUEST:
       case actions.GET_FIO_ADDRESSES_REQUEST:
       case actions.GET_FIO_DOMAINS_REQUEST:
-      case actions.FIO_SIGNATURE_ADDRESS_REQUEST:
+      case actions.FIO_SIGNATURE_REQUEST:
         return true;
       case actions.REFRESH_BALANCE_SUCCESS:
       case actions.REFRESH_BALANCE_FAILURE:
@@ -40,8 +42,8 @@ export default combineReducers({
       case actions.GET_FIO_ADDRESSES_FAILURE:
       case actions.GET_FIO_DOMAINS_SUCCESS:
       case actions.GET_FIO_DOMAINS_FAILURE:
-      case actions.FIO_SIGNATURE_ADDRESS_SUCCESS:
-      case actions.FIO_SIGNATURE_ADDRESS_FAILURE:
+      case actions.FIO_SIGNATURE_SUCCESS:
+      case actions.FIO_SIGNATURE_FAILURE:
         return false;
       default:
         return state;
@@ -344,22 +346,11 @@ export default combineReducers({
   },
   nftList(state: NFTTokenDoublet[] = [], action) {
     switch (action.type) {
-      case actions.FIO_SIGNATURE_ADDRESS_SUCCESS: {
-        const nftList = [];
-        for (const item of action.data.nfts) {
-          const nftItem = {
-            contractAddress: item.contract_address,
-            chainCode: item.chain_code,
-            tokenId: item.token_id,
-            url: item.url,
-            hash: item.hash,
-            metadata: item.metadata,
-          };
-          nftList.push(nftItem);
-        }
-        return nftList;
+      case actions.FIO_SIGNATURE_SUCCESS: {
+        return transformNft(action.data.nfts);
       }
       case LOGOUT_SUCCESS:
+      case actions.CLEAR_NFT_SIGNATURES:
         return [];
       default:
         return state;

--- a/client/src/routes.jsx
+++ b/client/src/routes.jsx
@@ -33,6 +33,7 @@ import EmailConfirmGatePage from './pages/EmailConfirmGatePage';
 import FioAddressSignaturesPage from './pages/FioAddressSignaturesPage';
 import FioAddressSignPage from './pages/FioAddressSignPage';
 import FioAddressNftPage from './pages/FioAddressNftPage';
+import NftValidationPage from './pages/NftValidationPage';
 
 import { ROUTES } from './constants/routes';
 
@@ -149,6 +150,12 @@ const Routes = () => (
         <Route
           path={ROUTES.TERMS_OF_SERVICE}
           component={TermsOfServicePage}
+          exact
+        />
+
+        <Route
+          path={ROUTES.NFT_VALIDATION}
+          component={NftValidationPage}
           exact
         />
 

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -1,4 +1,5 @@
 import { EdgeAccount } from 'edge-core-js';
+import { NftItem } from '@fioprotocol/fiosdk/src/entities/NftItem';
 
 export type Domain = { domain: string; free?: boolean };
 
@@ -100,7 +101,12 @@ export type NFTTokenDoublet = {
   url?: string;
   hash?: string;
   metadata?: string;
+  fioAddress?: string;
 };
+
+export type NftTokenResponse = {
+  fio_address?: string;
+} & NftItem;
 
 export type WalletKeysObj = {
   [walletId: string]: {
@@ -215,3 +221,5 @@ export type EmailConfirmationStateData = {
   refCode?: string;
   refProfileQueryParams?: RefQueryParams;
 };
+
+export type CommonObjectProps = { [key: string]: string };

--- a/client/src/util/fio.ts
+++ b/client/src/util/fio.ts
@@ -1,6 +1,8 @@
 import apis from '../api/index';
 import { sleep } from '../utils';
 
+import { NftTokenResponse } from '../types';
+
 export const waitForAddressRegistered = async (fioAddress: string) => {
   const CALL_INTERVAL = 3000; // 3 sec
   const WAIT_TIMEOUT = 60000; // 60 sec
@@ -23,4 +25,21 @@ export const waitForAddressRegistered = async (fioAddress: string) => {
   };
 
   return checkAddressIsRegistered();
+};
+
+export const transformNft = (nfts: NftTokenResponse[]) => {
+  const nftList = [];
+  for (const item of nfts) {
+    const nftItem = {
+      fioAddress: item.fio_address,
+      contractAddress: item.contract_address,
+      chainCode: item.chain_code,
+      tokenId: item.token_id,
+      url: item.url,
+      hash: item.hash,
+      metadata: item.metadata,
+    };
+    nftList.push(nftItem);
+  }
+  return nftList;
 };


### PR DESCRIPTION
* Add color prop to InfoBadge component

* Create NFT Validation Page

* Create common CustomDropdown component

* Create generic results titles and items

* Add loader

* Pass search params to getNFTs

* Get NFTs on submit

* Create modal for NFT Signature item

* Set types, results in component state, fixes

* Move NftValidatiion components to folder with page

* Fix eslint OPTIONS render methods. 

* Form validation. 

* Empty values placholder. 

* Reset results on search. Types changes.

Co-authored-by: andreyvEze <andreyv@eze.tech>