### PR TITLE
Fix. DASH-197 Admin panel order details payments received fio issue

### DIFF
--- a/client/src/constants/purchase.ts
+++ b/client/src/constants/purchase.ts
@@ -54,6 +54,12 @@ export const PAYMENT_OPTIONS = {
   CRYPTO: 'CRYPTO',
 } as const;
 
+export const PAYMENT_OPTIONS_LABEL = {
+  [PAYMENT_OPTIONS.FIO]: 'FIO',
+  [PAYMENT_OPTIONS.CREDIT_CARD]: 'Credit Card',
+  [PAYMENT_OPTIONS.CRYPTO]: 'Crypto',
+};
+
 export const PAYMENT_SPENT_TYPES = {
   ORDER: 1,
   ACTION: 2,

--- a/client/src/pages/AdminOrdersPage/AdminOrdersPage.tsx
+++ b/client/src/pages/AdminOrdersPage/AdminOrdersPage.tsx
@@ -7,7 +7,10 @@ import AdminOrderModal from './components/AdminOrderModal/AdminOrderModal';
 import usePagination from '../../hooks/usePagination';
 import { formatDateToLocale } from '../../helpers/stringFormatters';
 
-import { PURCHASE_RESULTS_STATUS_LABELS } from '../../constants/purchase';
+import {
+  PURCHASE_RESULTS_STATUS_LABELS,
+  PAYMENT_OPTIONS_LABEL,
+} from '../../constants/purchase';
 
 import { AdminUser, OrderItem } from '../../types';
 
@@ -82,7 +85,9 @@ const AdminOrdersPage: React.FC<Props> = props => {
                     <th>{order.user ? order.user.email : order.userEmail}</th>
                     <th>{order.total || 0}</th>
                     <th>{order.refProfileName || 'FIO Dashboard'}</th>
-                    <th>{order.currency?.toUpperCase() || 'N/A'}</th>
+                    <th>
+                      {PAYMENT_OPTIONS_LABEL[order.paymentProcessor] || 'N/A'}
+                    </th>
                     <th>{PURCHASE_RESULTS_STATUS_LABELS[order.status]}</th>
                   </tr>
                 ))

--- a/client/src/pages/AdminOrdersPage/AdminOrdersPage.tsx
+++ b/client/src/pages/AdminOrdersPage/AdminOrdersPage.tsx
@@ -56,6 +56,7 @@ const AdminOrdersPage: React.FC<Props> = props => {
               <th scope="col">User</th>
               <th scope="col">Amount</th>
               <th scope="col">Ref Profile</th>
+              <th scope="col">Payment</th>
               <th scope="col">Status</th>
             </tr>
           </thead>
@@ -77,6 +78,7 @@ const AdminOrdersPage: React.FC<Props> = props => {
                     <th>{order.user ? order.user.email : order.userEmail}</th>
                     <th>{order.total || 0}</th>
                     <th>{order.refProfileName || 'FIO Dashboard'}</th>
+                    <th>{order.currency?.toUpperCase() || 'N/A'}</th>
                     <th>{PURCHASE_RESULTS_STATUS_LABELS[order.status]}</th>
                   </tr>
                 ))

--- a/client/src/pages/AdminOrdersPage/AdminOrdersPage.tsx
+++ b/client/src/pages/AdminOrdersPage/AdminOrdersPage.tsx
@@ -45,6 +45,10 @@ const AdminOrdersPage: React.FC<Props> = props => {
     setShowOrderDetailsModal(true);
   };
 
+  const onClick = (orderId: string) => {
+    openOrderDetails(orderId);
+  };
+
   return (
     <>
       <div className={classes.tableContainer}>
@@ -62,11 +66,11 @@ const AdminOrdersPage: React.FC<Props> = props => {
           </thead>
           <tbody>
             {ordersList?.length
-              ? ordersList.map((order, i) => (
+              ? ordersList.map(order => (
                   <tr
                     key={order.id}
                     className={classes.orderItem}
-                    onClick={openOrderDetails.bind(null, order.id)}
+                    onClick={() => onClick(order.id)}
                   >
                     <th>
                       {' '}

--- a/client/src/pages/AdminOrdersPage/components/AdminOrderModal/AdminOrderModal.tsx
+++ b/client/src/pages/AdminOrdersPage/components/AdminOrderModal/AdminOrderModal.tsx
@@ -14,6 +14,7 @@ import {
   BC_TX_STATUS_LABELS,
   PURCHASE_RESULTS_STATUS_LABELS,
   PAYMENT_STATUSES,
+  PAYMENT_OPTIONS_LABEL,
 } from '../../../../constants/purchase';
 import { CURRENCY_CODES } from '../../../../constants/common';
 
@@ -116,7 +117,9 @@ const AdminOrderModal: React.FC<Props> = ({
             {renderOrderItemFieldData('User', orderItem.user.email)}
             {renderOrderItemFieldData(
               'Payment Type',
-              orderPayment?.processor || null,
+              orderPayment?.processor
+                ? PAYMENT_OPTIONS_LABEL[orderPayment?.processor]
+                : 'N/A',
             )}
             {renderOrderItemFieldData(
               'Status',

--- a/client/src/pages/AdminOrdersPage/components/AdminOrderModal/AdminOrderModal.tsx
+++ b/client/src/pages/AdminOrdersPage/components/AdminOrderModal/AdminOrderModal.tsx
@@ -17,6 +17,8 @@ import {
 } from '../../../../constants/purchase';
 import { CURRENCY_CODES } from '../../../../constants/common';
 
+import apis from '../../../../api';
+
 import { OrderItem } from '../../../../types';
 
 import classes from '../../styles/AdminOrderModal.module.scss';
@@ -71,9 +73,23 @@ const AdminOrderModal: React.FC<Props> = ({
   const renderPaymentReceived = () => {
     if (orderPayment.status !== PAYMENT_STATUSES.COMPLETED) return '-';
 
-    return orderPayment.price
-      ? orderPayment.price + ` ${orderPayment.currency.toUpperCase()}`
-      : 'None';
+    if (!orderPayment.price) return 'None';
+
+    let orderPaymentPrice =
+      orderPayment.price + ` ${orderPayment.currency.toUpperCase()}`;
+
+    if (orderPayment.currency === CURRENCY_CODES.FIO) {
+      orderPaymentPrice =
+        apis.fio.sufToAmount(Number(orderPayment.price)).toFixed(2) +
+        ` ${orderPayment.currency.toUpperCase()}`;
+
+      orderPaymentPrice += ` (${apis.fio.convertFioToUsdc(
+        Number(orderPayment.price),
+        Number(orderItem.roe),
+      )} USDC)`;
+    }
+
+    return orderPaymentPrice;
   };
 
   return (

--- a/client/src/pages/AdminOrdersPage/components/AdminOrderModal/AdminOrderModalContext.tsx
+++ b/client/src/pages/AdminOrdersPage/components/AdminOrderModal/AdminOrderModalContext.tsx
@@ -146,7 +146,7 @@ const setHistory = (
         statusMsg += statusNotes;
       } else {
         if (status === BC_TX_STATUSES.SUCCESS) {
-          statusMsg += `TX ID - ${bt.txId}`;
+          statusMsg += `TX ID - ${bt.txId || 'N/A'}`;
           statusMsg += `\nFee collected: ${
             bt?.feeCollected
               ? `${apis.fio.sufToAmount(bt.feeCollected)} FIO`

--- a/client/src/pages/AdminOrdersPage/components/AdminOrderModal/AdminOrderModalContext.tsx
+++ b/client/src/pages/AdminOrdersPage/components/AdminOrderModal/AdminOrderModalContext.tsx
@@ -16,12 +16,7 @@ import {
 } from '../../../../constants/purchase';
 import { CURRENCY_CODES } from '../../../../constants/common';
 
-import {
-  BcTx,
-  OrderItem,
-  OrderPaymentItem,
-  PaymentOptionsProps,
-} from '../../../../types';
+import { BcTx, OrderItem, OrderPaymentItem } from '../../../../types';
 
 type PaymentSpentType = typeof PAYMENT_SPENT_TYPES[keyof typeof PAYMENT_SPENT_TYPES];
 type PaymentStatusType = typeof PAYMENT_STATUSES[keyof typeof PAYMENT_STATUSES];
@@ -73,7 +68,7 @@ const setHistory = (
       amount: status === PAYMENT_STATUSES.COMPLETED ? payment.price : '0.00',
       currency: payment.currency.toUpperCase(),
       status: `${
-        PAYMENT_OPTION_LABEL[payment.processor as PaymentOptionsProps]
+        PAYMENT_OPTION_LABEL[payment.processor]
       } notification received (${
         payment.externalId
       }) \nStatus: ${PAYMENTS_STATUSES_TITLES[status as PaymentStatusType] ||

--- a/client/src/pages/AdminOrdersPage/components/AdminOrderModal/AdminOrderModalContext.tsx
+++ b/client/src/pages/AdminOrdersPage/components/AdminOrderModal/AdminOrderModalContext.tsx
@@ -149,7 +149,7 @@ const setHistory = (
           statusMsg += `TX ID - ${bt.txId || 'N/A'}`;
           statusMsg += `\nFee collected: ${
             bt?.feeCollected
-              ? `${apis.fio.sufToAmount(bt.feeCollected)} FIO`
+              ? `${apis.fio.sufToAmount(bt.feeCollected).toFixed(2)} FIO`
               : 'N/A'
           }`;
         } else {

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -656,6 +656,7 @@ export type OrderItem = {
   publicKey: string;
   createdAt: string;
   status: number;
+  currency?: PaymentCurrency;
   items?: {
     action: string;
     address?: string;

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -622,7 +622,7 @@ export type OrderPaymentItem = {
     updatedAt: string;
   }[];
   price?: string;
-  processor: string;
+  processor: PaymentOptionsProps;
   spentType: number;
   status: number;
   updatedAt: string;
@@ -657,6 +657,7 @@ export type OrderItem = {
   createdAt: string;
   status: number;
   currency?: PaymentCurrency;
+  paymentProcessor: PaymentOptionsProps;
   items?: {
     action: string;
     address?: string;

--- a/server/src/models/Order.mjs
+++ b/server/src/models/Order.mjs
@@ -174,6 +174,7 @@ export class Order extends Base {
           o."updatedAt",
           p.price,
           p.currency,
+          p.processor as "paymentProcessor",
           u.email as "userEmail",
           rp.label as "refProfileName"
         FROM "orders" o

--- a/server/src/services/orders/Update.mjs
+++ b/server/src/services/orders/Update.mjs
@@ -174,13 +174,13 @@ export default class OrdersUpdate extends Base {
                 id: blockchainTransactionId,
               });
 
-              bcTx.txId = transaction_id || 'free';
+              bcTx.txId = transaction_id;
               bcTx.status = BlockchainTransaction.STATUS.SUCCESS;
               bcTx.feeCollected = fee_collected;
               await bcTx.save();
             } else {
               bcTx = await BlockchainTransaction.create({
-                txId: transaction_id || 'free',
+                txId: transaction_id,
                 action: orderItem.action,
                 status: BlockchainTransaction.STATUS.SUCCESS,
                 data: { params: orderItem.params },

--- a/server/src/services/orders/Update.mjs
+++ b/server/src/services/orders/Update.mjs
@@ -97,10 +97,21 @@ export default class OrdersUpdate extends Base {
 
     if (data.results && data.results.paymentOption === Payment.PROCESSOR.FIO) {
       try {
+        const totalFioNativePrice = data.results.registered.reduce((acc, regItem) => {
+          if (!isNaN(Number(regItem.fee_collected))) return acc + regItem.fee_collected;
+          return acc;
+        }, 0);
+
         // todo: do we need to create PaymentEventLog here?
         await Payment.update(
-          { status: Payment.STATUS.COMPLETED },
-          { where: { id: order.Payments[0].id } },
+          {
+            status: Payment.STATUS.COMPLETED,
+            price: totalFioNativePrice || null,
+            currency: Payment.PROCESSOR.FIO,
+          },
+          {
+            where: { id: order.Payments[0].id },
+          },
         );
 
         // todo: check data.results.partial


### PR DESCRIPTION
- Show N/A instead of null in TX ID field at admin order details
- Add price to fio payment table record
- Remove free from blockchain transaction id
- Add payment currency column to admin order's table
- Change openOrderDetails bind to onClick