### PR TITLE
Fix. DASH-237 Fix stripe info badge on in progress state

### DIFF
--- a/client/src/pages/PurchasePage/components/InfoBadgeComponent.tsx
+++ b/client/src/pages/PurchasePage/components/InfoBadgeComponent.tsx
@@ -35,7 +35,8 @@ export const InfoBadgeComponent: React.FC<InfoBadgeComponentProps> = props => {
   if (
     purchaseStatus === PURCHASE_RESULTS_STATUS.PENDING ||
     purchaseStatus === PURCHASE_RESULTS_STATUS.PAYMENT_PENDING ||
-    purchaseStatus === PURCHASE_RESULTS_STATUS.PAYMENT_AWAITING
+    purchaseStatus === PURCHASE_RESULTS_STATUS.PAYMENT_AWAITING ||
+    purchaseStatus === PURCHASE_RESULTS_STATUS.TRANSACTION_PENDING
   ) {
     title = 'Confirmation in Progress';
     badgeUIType = BADGE_TYPES.INFO;


### PR DESCRIPTION
- Fix stripe info badge on in progress state, add TRANSACTION_PENDING 