### PR TITLE
Fix. DASH-434 BitPay issues fixes

### DIFF
--- a/client/src/pages/CheckoutPage/components/BitpayPaymentOption.tsx
+++ b/client/src/pages/CheckoutPage/components/BitpayPaymentOption.tsx
@@ -61,6 +61,7 @@ export const BitpayPaymentOption: React.FC<BitPayOptionProps> = props => {
     window.addEventListener('message', handleBitPayPaymentMessage);
     return () => {
       window.removeEventListener('message', handleBitPayPaymentMessage);
+      window.bitpay && window.bitpay.hideFrame();
     };
   }, [handleBitPayPaymentMessage]);
 

--- a/server/src/external/payment-processor/bitpay.mjs
+++ b/server/src/external/payment-processor/bitpay.mjs
@@ -61,6 +61,7 @@ class BitPay extends PaymentProcessor {
       status,
       transactions,
       token,
+      transactionCurrency,
     } = bitPayInvoice;
 
     const data = {
@@ -77,6 +78,7 @@ class BitPay extends PaymentProcessor {
       transactions,
       txn_id: id,
       token,
+      transactionCurrency,
     };
 
     return data;

--- a/server/src/external/payment-processor/bitpay.mjs
+++ b/server/src/external/payment-processor/bitpay.mjs
@@ -162,7 +162,14 @@ class BitPay extends PaymentProcessor {
       secret: paymentIntent.billId,
       amount,
       currency,
+      forceInitialWebhook: true,
     };
+  }
+
+  async getInvoiceWebHook(invoiceId) {
+    const bitPayClient = await this.getBitPayClient();
+
+    return await bitPayClient.GetInvoiceWebHook(invoiceId);
   }
 
   async cancel(id) {

--- a/server/src/external/payment-processor/bitpay.mjs
+++ b/server/src/external/payment-processor/bitpay.mjs
@@ -66,6 +66,7 @@ class BitPay extends PaymentProcessor {
     const data = {
       id,
       amountPaid,
+      amount: price,
       currency,
       email: buyerProvidedEmail,
       expirationTime,

--- a/server/src/models/Order.mjs
+++ b/server/src/models/Order.mjs
@@ -550,7 +550,7 @@ export class Order extends Base {
     let paidWith = 'N/A';
     if (payment) {
       paidWith = await getPaidWith({
-        isCreditCardProcessor: payment.processor === Payment.PROCESSOR.STRIPE,
+        paymentProcessor: payment.processor,
         publicKey,
         userId: user ? user.id : null,
         payment,
@@ -750,7 +750,7 @@ export class Order extends Base {
     let paidWith = 'N/A';
     if (payment) {
       paidWith = await getPaidWith({
-        isCreditCardProcessor: payment.processor === Payment.PROCESSOR.STRIPE,
+        paymentProcessor: payment.processor,
         publicKey,
         userId: user.id || null,
         payment,

--- a/server/src/models/Payment.mjs
+++ b/server/src/models/Payment.mjs
@@ -228,6 +228,10 @@ export class Payment extends Base {
       });
     }
 
+    if (extPaymentParams.forceInitialWebhook && extPaymentParams.externalPaymentId) {
+      await paymentProcessor.getInvoiceWebHook(extPaymentParams.externalPaymentId);
+    }
+
     return {
       id: orderPayment.id,
       processor: paymentProcessorKey,

--- a/server/src/models/Payment.mjs
+++ b/server/src/models/Payment.mjs
@@ -160,9 +160,11 @@ export class Payment extends Base {
       if (exPayment) {
         try {
           const pExtId = exPayment.externalId;
+          const pExtPaymentProcessor = Payment.getPaymentProcessor(exPayment.processor);
+
           exPayment.status = Payment.STATUS.CANCELLED;
           await exPayment.save();
-          if (pExtId) await paymentProcessor.cancel(pExtId);
+          if (pExtId && pExtPaymentProcessor) await pExtPaymentProcessor.cancel(pExtId);
         } catch (e) {
           logger.error(
             `Existing Payment removing error ${e.message}. Order #${exOrder.number}. Payment ${exPayment.id}`,

--- a/server/src/services/updateOrderStatus.mjs
+++ b/server/src/services/updateOrderStatus.mjs
@@ -82,7 +82,10 @@ const handleOrderPaymentInfo = async ({ orderItems, payment, paidWith, number })
 
   const orderPaymentInfo = {};
 
-  const isCreditCardProcessor = processor === Payment.PROCESSOR.STRIPE;
+  const isExternalProcessor = [
+    Payment.PROCESSOR.STRIPE,
+    Payment.PROCESSOR.BITPAY,
+  ].includes(processor);
   const isFioProcessor = processor === Payment.PROCESSOR.FIO;
 
   const orderItemsTotalAmount = countTotalPriceAmount(orderItems);
@@ -109,7 +112,7 @@ const handleOrderPaymentInfo = async ({ orderItems, payment, paidWith, number })
     }
   }
 
-  if (isCreditCardProcessor && paymentData) {
+  if (isExternalProcessor && paymentData) {
     orderPaymentInfo.paidWith = paidWith;
     orderPaymentInfo.orderNumber = number;
     orderPaymentInfo.total = `${orderItemsTotalAmount.usdcTotal.toFixed(2)} USDC`;
@@ -130,7 +133,6 @@ const createPurchaseConfirmationNotification = async order => {
     const payment =
       payments.find(payment => payment.spentType === Payment.SPENT_TYPE.ORDER) || {};
 
-    const isCreditCardProcessor = payment.processor === Payment.PROCESSOR.STRIPE;
     const isFioProcessor = payment.processor === Payment.PROCESSOR.FIO;
 
     const successedOrderItemsArr = items.filter(
@@ -144,7 +146,7 @@ const createPurchaseConfirmationNotification = async order => {
     );
 
     const paidWith = await getPaidWith({
-      isCreditCardProcessor,
+      paymentProcessor: payment.processor,
       publicKey,
       userId,
       payment,

--- a/server/src/utils/order.mjs
+++ b/server/src/utils/order.mjs
@@ -24,7 +24,7 @@ const getCreditCardName = creditCardData => {
 };
 
 export const getPaidWith = async ({
-  isCreditCardProcessor,
+  paymentProcessor,
   publicKey,
   userId,
   payment,
@@ -32,13 +32,22 @@ export const getPaidWith = async ({
 }) => {
   if (isCanceledStatus) return 'Not Paid';
 
-  if (isCreditCardProcessor) {
+  if (paymentProcessor === Payment.PROCESSOR.STRIPE) {
     const { data: paymentData } = payment;
 
     const { webhookData: { charges: { data: creditCardData = [] } = {} } = {} } =
       paymentData || {};
 
     return getCreditCardName(creditCardData[0]);
+  }
+
+  if (paymentProcessor === Payment.PROCESSOR.BITPAY) {
+    const { data: paymentData } = payment;
+    const { webhookData: { transactionCurrency } = {} } = paymentData || {};
+
+    if (!transactionCurrency) return `${paymentProcessor} N/A`;
+
+    return `${paymentProcessor} ${transactionCurrency}`;
   }
 
   return await getFioWalletName(publicKey, userId);


### PR DESCRIPTION
- Hide BitPay modal on checkout leave
- Handle paidWith for BitPay, paidWith function updates
- Set amount as a price for BitPay webhook data
- Force BitPay webhook for getting payment data
- Use the same payment processor as canceled order