### PR TITLE
DASH-528: Don't show login modal on logout

### DIFF
--- a/client/src/components/MainHeader/MainHeader.tsx
+++ b/client/src/components/MainHeader/MainHeader.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { useHistory } from 'react-router';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { MainHeaderContainer } from '../MainHeaderContainer';
@@ -17,6 +18,7 @@ const MainHeader: React.FC<MainHeaderProps> = props => {
     isMaintenance,
   } = props;
   const [isMenuOpen, toggleMenuOpen] = useState(false);
+  const history = useHistory();
 
   const closeMenu = useCallback(() => {
     toggleMenuOpen(false);
@@ -30,11 +32,13 @@ const MainHeader: React.FC<MainHeaderProps> = props => {
   const logout = useCallback(() => {
     closeMenu();
     logoutFn();
-  }, [closeMenu, logoutFn]);
+    history.push('/logout=true');
+  }, [closeMenu, logoutFn, history]);
 
   useEffect(() => {
     const url = new URL(window.location.href);
-    const isSilentLogout = url.searchParams.get('logout') === 'silent';
+    const isLogout = url.searchParams.get('logout');
+    const isSilentLogout = isLogout === 'silent';
     if (isSilentLogout) return;
 
     if (
@@ -42,7 +46,8 @@ const MainHeader: React.FC<MainHeaderProps> = props => {
       !isAuthenticated &&
       locationState &&
       locationState.from &&
-      locationState.from.pathname
+      locationState.from.pathname &&
+      !isLogout
     ) {
       showLogin();
     }

--- a/client/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/client/src/components/PrivateRoute/PrivateRoute.tsx
@@ -51,7 +51,10 @@ export const PrivateRoute: React.FC<RouteProps & OwnProps> = ({
             <Redirect
               to={{
                 pathname: ROUTES.HOME,
-                state: { from: props.location, options: redirectOptions },
+                state: {
+                  from: props.location,
+                  options: redirectOptions,
+                },
               }}
             />
           );

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -529,7 +529,10 @@ export type RedirectLinkData = {
 };
 
 export type PrivateRedirectLocationState = {
-  from?: { pathname?: string; search?: string };
+  from?: {
+    pathname?: string;
+    search?: string;
+  };
   options?: { setKeysForAction?: boolean };
 };
 

--- a/client/src/util/hooks.ts
+++ b/client/src/util/hooks.ts
@@ -95,14 +95,14 @@ export function useFioWallet(
       const selected = getElementByFioName({ fioNameList, name });
       setPublicKey((selected && selected.walletPublicKey) || '');
     }
-  }, [wallets, fioNameList, name]);
+  }, [wallets, fioNameList, name, isAuth]);
 
   useEffect(() => {
     if (publicKey != null && publicKey) {
       dispatch(refreshBalance(publicKey));
       setWalletSetting(false);
     }
-  }, [publicKey]);
+  }, [publicKey, dispatch]);
 
   // FioWalletDoublet
   const wallet: FioWalletDoublet =


### PR DESCRIPTION
- Sign In Modal Window should not be shown on Log Out. 
- Sign In Modal Window should be shown only if user navigates to the private route.
- Sign In Modal Window should also be shown if user was auto log out after 30 min.