### PR TITLE
DASH-641: fixes added

### DIFF
--- a/client/src/components/AddressWidget/AddressWidget.tsx
+++ b/client/src/components/AddressWidget/AddressWidget.tsx
@@ -35,6 +35,7 @@ type Props = {
   showSubmitButton?: boolean;
   placeHolderText?: string;
   clearButton?: boolean;
+  onInputChanged?: (value: string) => string;
 };
 
 const AddressWidget: React.FC<Props> = props => {
@@ -59,6 +60,7 @@ const AddressWidget: React.FC<Props> = props => {
     showSubmitButton = true,
     placeHolderText,
     clearButton,
+    onInputChanged,
   } = props;
 
   return (
@@ -87,6 +89,7 @@ const AddressWidget: React.FC<Props> = props => {
         showSubmitButton={showSubmitButton}
         placeHolderText={placeHolderText}
         clearButton={clearButton}
+        onInputChanged={onInputChanged}
       />
       <SignInWidget show={!isAuthenticated && showSignInWidget} />
     </div>

--- a/client/src/components/AddressWidget/AddressWidget.tsx
+++ b/client/src/components/AddressWidget/AddressWidget.tsx
@@ -33,6 +33,8 @@ type Props = {
   notification?: TwitterNotification;
   customHandleSubmit?: ({ address }: { address: string }) => Promise<void>;
   showSubmitButton?: boolean;
+  placeHolderText?: string;
+  clearButton?: boolean;
 };
 
 const AddressWidget: React.FC<Props> = props => {
@@ -55,6 +57,8 @@ const AddressWidget: React.FC<Props> = props => {
     notification,
     customHandleSubmit,
     showSubmitButton = true,
+    placeHolderText,
+    clearButton,
   } = props;
 
   return (
@@ -81,6 +85,8 @@ const AddressWidget: React.FC<Props> = props => {
         notification={notification}
         customHandleSubmit={customHandleSubmit}
         showSubmitButton={showSubmitButton}
+        placeHolderText={placeHolderText}
+        clearButton={clearButton}
       />
       <SignInWidget show={!isAuthenticated && showSignInWidget} />
     </div>

--- a/client/src/components/AddressWidget/AddressWidget.tsx
+++ b/client/src/components/AddressWidget/AddressWidget.tsx
@@ -26,15 +26,13 @@ type Props = {
   isReverseColors?: boolean;
   isDarkWhite?: boolean;
   formAction?: boolean;
-  suffix?: boolean;
-  prefixText?: string;
+  suffixText?: string;
   convert?: (value: string) => string;
   formatOnFocusOut?: boolean;
   notification?: TwitterNotification;
   customHandleSubmit?: ({ address }: { address: string }) => Promise<void>;
   showSubmitButton?: boolean;
   placeHolderText?: string;
-  clearButton?: boolean;
   onInputChanged?: (value: string) => string;
 };
 
@@ -51,15 +49,13 @@ const AddressWidget: React.FC<Props> = props => {
     showSignInWidget,
     subtitle,
     formAction,
-    suffix,
-    prefixText,
+    suffixText,
     convert,
     formatOnFocusOut,
     notification,
     customHandleSubmit,
     showSubmitButton = true,
     placeHolderText,
-    clearButton,
     onInputChanged,
   } = props;
 
@@ -80,15 +76,13 @@ const AddressWidget: React.FC<Props> = props => {
         links={links}
         isDarkWhite={isDarkWhite}
         formAction={formAction}
-        suffix={suffix}
-        prefixText={prefixText}
+        suffixText={suffixText}
         convert={convert}
         formatOnFocusOut={formatOnFocusOut}
         notification={notification}
         customHandleSubmit={customHandleSubmit}
         showSubmitButton={showSubmitButton}
         placeHolderText={placeHolderText}
-        clearButton={clearButton}
         onInputChanged={onInputChanged}
       />
       <SignInWidget show={!isAuthenticated && showSignInWidget} />

--- a/client/src/components/AddressWidget/components/FormComponent/FormComponent.tsx
+++ b/client/src/components/AddressWidget/components/FormComponent/FormComponent.tsx
@@ -5,7 +5,10 @@ import classnames from 'classnames';
 
 import SubmitButton from '../../../common/SubmitButton/SubmitButton';
 import { ExclamationIcon } from '../../../ExclamationIcon';
-import TextInput, { INPUT_COLOR_SCHEMA } from '../../../Input/TextInput';
+import TextInput, {
+  INPUT_COLOR_SCHEMA,
+  INPUT_UI_STYLES,
+} from '../../../Input/TextInput';
 import NotificationBadge from '../../../NotificationBadge';
 
 import { QUERY_PARAMS_NAMES } from '../../../../constants/queryParams';
@@ -23,15 +26,13 @@ type Props = {
   isReverseColors?: boolean;
   isDarkWhite?: boolean;
   formAction?: boolean;
-  suffix?: boolean;
-  prefixText?: string;
+  suffixText?: string;
   convert?: (value: string) => string;
   formatOnFocusOut?: boolean;
   notification?: TwitterNotification;
   customHandleSubmit?: ({ address }: { address: string }) => Promise<void>;
   showSubmitButton?: boolean;
   placeHolderText?: string;
-  clearButton?: boolean;
   onInputChanged?: (value: string) => string;
 };
 
@@ -94,15 +95,13 @@ export const FormComponent: React.FC<Props> = props => {
     isDarkWhite,
     links,
     formAction,
-    suffix,
-    prefixText,
+    suffixText,
     convert,
     formatOnFocusOut,
     notification,
     customHandleSubmit,
     showSubmitButton = true,
     placeHolderText = 'Enter a Username',
-    clearButton = true,
     onInputChanged,
   } = props;
 
@@ -146,15 +145,13 @@ export const FormComponent: React.FC<Props> = props => {
                 type="text"
                 placeholder={placeHolderText}
                 colorSchema={INPUT_COLOR_SCHEMA.INDIGO_AND_WHITE}
+                uiType={INPUT_UI_STYLES.INDIGO_WHITE}
                 component={TextInput}
                 hideError="true"
                 lowerCased
-                prefix={prefixText}
-                suffix={suffix}
+                suffix={suffixText}
                 formatOnBlur={formatOnFocusOut}
                 format={convert}
-                defaultValue=""
-                clearButton={clearButton}
                 parse={onInputChanged}
               />
             </div>

--- a/client/src/components/AddressWidget/components/FormComponent/FormComponent.tsx
+++ b/client/src/components/AddressWidget/components/FormComponent/FormComponent.tsx
@@ -30,6 +30,8 @@ type Props = {
   notification?: TwitterNotification;
   customHandleSubmit?: ({ address }: { address: string }) => Promise<void>;
   showSubmitButton?: boolean;
+  placeHolderText?: string;
+  clearButton?: boolean;
 };
 
 type ActionButtonProps = {
@@ -98,6 +100,8 @@ export const FormComponent: React.FC<Props> = props => {
     notification,
     customHandleSubmit,
     showSubmitButton = true,
+    placeHolderText = 'Enter a Username',
+    clearButton = true,
   } = props;
 
   const history = useHistory();
@@ -138,7 +142,7 @@ export const FormComponent: React.FC<Props> = props => {
               <Field
                 name="address"
                 type="text"
-                placeholder="Enter a Username"
+                placeholder={placeHolderText}
                 colorSchema={INPUT_COLOR_SCHEMA.INDIGO_AND_WHITE}
                 component={TextInput}
                 hideError="true"
@@ -148,6 +152,7 @@ export const FormComponent: React.FC<Props> = props => {
                 formatOnBlur={formatOnFocusOut}
                 format={convert}
                 defaultValue=""
+                clearButton={clearButton}
               />
             </div>
             {showSubmitButton && (

--- a/client/src/components/AddressWidget/components/FormComponent/FormComponent.tsx
+++ b/client/src/components/AddressWidget/components/FormComponent/FormComponent.tsx
@@ -32,6 +32,7 @@ type Props = {
   showSubmitButton?: boolean;
   placeHolderText?: string;
   clearButton?: boolean;
+  onInputChanged?: (value: string) => string;
 };
 
 type ActionButtonProps = {
@@ -102,6 +103,7 @@ export const FormComponent: React.FC<Props> = props => {
     showSubmitButton = true,
     placeHolderText = 'Enter a Username',
     clearButton = true,
+    onInputChanged,
   } = props;
 
   const history = useHistory();
@@ -153,6 +155,7 @@ export const FormComponent: React.FC<Props> = props => {
                 format={convert}
                 defaultValue=""
                 clearButton={clearButton}
+                parse={onInputChanged}
               />
             </div>
             {showSubmitButton && (

--- a/client/src/components/FCHBanner/FCHBanner.module.scss
+++ b/client/src/components/FCHBanner/FCHBanner.module.scss
@@ -78,6 +78,7 @@
 @include sm {
   .container {
     padding: 70px 52px;
+    height: 660px;
 
     .row {
       flex-direction: column;

--- a/client/src/components/Input/Input.module.scss
+++ b/client/src/components/Input/Input.module.scss
@@ -421,7 +421,7 @@
 }
 
 .suffix {
-  right: 40px;
+  right: 10px;
   background: none;
   color: #765cd6;
 }

--- a/client/src/components/Input/Input.module.scss
+++ b/client/src/components/Input/Input.module.scss
@@ -299,6 +299,10 @@
 
       &[data-clear='true'] {
         padding-right: 35px;
+
+        &.suffixSpace {
+          padding-right: 135px;
+        }
       }
     }
 
@@ -308,6 +312,10 @@
 
     &.hasPasteButton {
       padding-right: 45px;
+    }
+
+    &.suffixSpace {
+      padding-right: 80px;
     }
 
     &.iw {
@@ -421,9 +429,19 @@
 }
 
 .suffix {
-  right: 10px;
-  background: none;
-  color: #765cd6;
+  position: absolute;
+  color: $baltic-sea;
+  top: 50%;
+  right: 20px;
+  transform: translateY(-50%);
+
+  &.indigoWhite {
+    color: $light-indigo;
+  }
+
+  &.hasIconsLeft {
+    right: 50px;
+  }
 }
 
 .pin {

--- a/client/src/components/Input/StaticInputParts.tsx
+++ b/client/src/components/Input/StaticInputParts.tsx
@@ -99,21 +99,39 @@ export const Prefix: React.FC<{
   hasError?: boolean;
   uiType?: string;
   highZIndex?: boolean;
-  suffix?: boolean;
-}> = ({ prefix, hasError, uiType, highZIndex, suffix }) => {
+}> = ({ prefix, hasError, uiType, highZIndex }) => {
   if (!prefix?.length) return null;
 
   return (
     <div
       className={classnames(
         classes.prefix,
-        suffix && classes.suffix,
         hasError && classes.error,
         uiType && classes[uiType],
         highZIndex && classes.highZIndex,
       )}
     >
       {prefix}
+    </div>
+  );
+};
+
+export const Suffix: React.FC<{
+  hasIconsLeft?: boolean;
+  suffix: string;
+  uiType?: string;
+}> = ({ hasIconsLeft, suffix, uiType }) => {
+  if (!suffix.length) return null;
+
+  return (
+    <div
+      className={classnames(
+        classes.suffix,
+        uiType && classes[uiType],
+        hasIconsLeft && classes.hasIconsLeft,
+      )}
+    >
+      {suffix}
     </div>
   );
 };

--- a/client/src/components/Input/StaticInputParts.tsx
+++ b/client/src/components/Input/StaticInputParts.tsx
@@ -121,7 +121,7 @@ export const Suffix: React.FC<{
   suffix: string;
   uiType?: string;
 }> = ({ hasIconsLeft, suffix, uiType }) => {
-  if (!suffix.length) return null;
+  if (suffix && !suffix.length) return null;
 
   return (
     <div

--- a/client/src/components/Input/TextInput.tsx
+++ b/client/src/components/Input/TextInput.tsx
@@ -68,6 +68,7 @@ export type TextInputProps = {
   withoutBottomMargin?: boolean;
   hasItalicLabel?: boolean;
   hasErrorForced?: boolean;
+  clearButton?: boolean;
 };
 
 export const TextInput: React.ForwardRefRenderFunction<
@@ -106,6 +107,7 @@ export const TextInput: React.ForwardRefRenderFunction<
     withoutBottomMargin,
     hasItalicLabel,
     hasErrorForced,
+    clearButton,
     ...rest
   } = props;
   const {
@@ -253,21 +255,23 @@ export const TextInput: React.ForwardRefRenderFunction<
             {...connectWalletProps}
           />
         ) : null}
-        <ClearButton
-          isVisible={
-            (isInputHasValue || !!onClose) &&
-            (isWalletConnected ? true : !disabled) &&
-            !loading
-          }
-          onClear={clearInputFn}
-          onClose={onClose}
-          inputType={type}
-          isBW={isBW}
-          isIW={isIW}
-          isBigDoubleIcon={showConnectWalletButton && !isWalletConnected}
-          disabled={isWalletConnected ? false : disabled}
-          uiType={isWalletConnected ? 'whiteBlack' : uiType}
-        />
+        {clearButton && (
+          <ClearButton
+            isVisible={
+              (isInputHasValue || !!onClose) &&
+              (isWalletConnected ? true : !disabled) &&
+              !loading
+            }
+            onClear={clearInputFn}
+            onClose={onClose}
+            inputType={type}
+            isBW={isBW}
+            isIW={isIW}
+            isBigDoubleIcon={showConnectWalletButton && !isWalletConnected}
+            disabled={isWalletConnected ? false : disabled}
+            uiType={isWalletConnected ? 'whiteBlack' : uiType}
+          />
+        )}
         <ShowPasswordIcon
           isVisible={isInputHasValue && type === 'password'}
           showPass={showPass}

--- a/client/src/components/TweetShare/TweetShare.module.scss
+++ b/client/src/components/TweetShare/TweetShare.module.scss
@@ -53,3 +53,11 @@
 .blueText {
   color: $twitter-blue;
 }
+
+@include sm {
+  .tweetShareActionText {
+    width: 80%;
+    margin: 35px auto;
+    text-align: center;
+  }
+}

--- a/client/src/components/TweetShare/TweetShare.tsx
+++ b/client/src/components/TweetShare/TweetShare.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import TwitterIcon from '@mui/icons-material/Twitter';
 
+import { EventObjectType } from '../../types';
+
 import classes from './TweetShare.module.scss';
 
 type Props = {
@@ -10,6 +12,7 @@ type Props = {
   via: string;
   actionText: string;
   userfch: string;
+  onTweetShareClicked: () => void;
 };
 
 const TweetButton: React.FC<Props> = ({
@@ -19,12 +22,20 @@ const TweetButton: React.FC<Props> = ({
   via,
   actionText,
   userfch,
+  onTweetShareClicked,
 }) => {
   const generateShareUrl = () => {
     const encodedText = encodeURIComponent(text);
     const encodedUrl = encodeURIComponent(url);
 
     return `https://twitter.com/intent/tweet?text=${encodedText}&url=${encodedUrl}&via=${via}`;
+  };
+
+  const onTweetButtonClicked = (e: EventObjectType): void => {
+    e.preventDefault();
+    onTweetShareClicked();
+    window.open(generateShareUrl(), '_blank');
+    return;
   };
 
   return (
@@ -47,6 +58,7 @@ const TweetButton: React.FC<Props> = ({
               target="_blank"
               rel="noopener noreferrer"
               className={classes.tweetShareButton}
+              onClick={onTweetButtonClicked}
             >
               <TwitterIcon
                 fontSize="small"

--- a/client/src/constants/twitter.ts
+++ b/client/src/constants/twitter.ts
@@ -12,7 +12,7 @@ export const ADDRESS_WIDGET_CONTENT = {
   },
   formAction: false,
   fch: 'bob@twitter',
-  prefixText: '@twitter',
+  suffixText: '@twitter',
   placeHolderText: 'Enter Twitter Handle',
 };
 

--- a/client/src/constants/twitter.ts
+++ b/client/src/constants/twitter.ts
@@ -13,6 +13,7 @@ export const ADDRESS_WIDGET_CONTENT = {
   formAction: false,
   fch: 'bob@twitter',
   prefixText: '@twitter',
+  placeHolderText: 'Enter Twitter Handle',
 };
 
 export const TWITTER_SHARE_CONTENT = {

--- a/client/src/constants/twitter.ts
+++ b/client/src/constants/twitter.ts
@@ -19,7 +19,7 @@ export const ADDRESS_WIDGET_CONTENT = {
 export const TWITTER_SHARE_CONTENT = {
   text:
     'You can now send me crypto to my name@domain $FIO Crypto Handle. #CRYPTOTWITTER Get yours now ',
-  url: `${process.env.REACT_APP_API_BASE_URL}twitter-handle`,
+  url: `${document.location.href}`,
   hashtags: ['#CRYPTOTWITTER'],
   via: 'joinfio',
   actionText:

--- a/client/src/constants/twitter.ts
+++ b/client/src/constants/twitter.ts
@@ -19,7 +19,7 @@ export const ADDRESS_WIDGET_CONTENT = {
 export const TWITTER_SHARE_CONTENT = {
   text:
     'You can now send me crypto to my name@domain $FIO Crypto Handle. #CRYPTOTWITTER Get yours now ',
-  url: 'dashboard.fioprotocol.io/twitter-handle',
+  url: `${process.env.REACT_APP_API_BASE_URL}twitter-handle`,
   hashtags: ['#CRYPTOTWITTER'],
   via: 'joinfio',
   actionText:

--- a/client/src/pages/MainLayout/MainLayout.tsx
+++ b/client/src/pages/MainLayout/MainLayout.tsx
@@ -23,6 +23,7 @@ import PageTitle from '../../components/PageTitle/PageTitle';
 import { ContentContainer } from '../../components/ContentContainer';
 import { MainLayoutContainer } from '../../components/MainLayoutContainer';
 import FioLoader from '../../components/common/FioLoader/FioLoader';
+import TwitterMeta from '../../components/TwitterMeta/TwitterMeta';
 
 import { ROUTES } from '../../constants/routes';
 import { LINKS } from '../../constants/labels';
@@ -124,6 +125,7 @@ const MainLayout: React.FC<Props> = props => {
             />
           )}
           <MainHeader />
+          <TwitterMeta />
           <AutoLogout />
           <Ref />
           <Roe />

--- a/client/src/pages/TwitterPage/TwitterPage.tsx
+++ b/client/src/pages/TwitterPage/TwitterPage.tsx
@@ -291,7 +291,7 @@ const TwitterPage: React.FC<Props & RouteComponentProps> = props => {
         <AddressWidget
           {...ADDRESS_WIDGET_CONTENT}
           formAction={ADDRESS_WIDGET_CONTENT.formAction}
-          prefixText={ADDRESS_WIDGET_CONTENT.prefixText}
+          suffixText={ADDRESS_WIDGET_CONTENT.suffixText}
           convert={onFocusOut}
           notification={notification}
           customHandleSubmit={
@@ -302,9 +302,7 @@ const TwitterPage: React.FC<Props & RouteComponentProps> = props => {
           showSubmitButton={showSubmitButton}
           placeHolderText={ADDRESS_WIDGET_CONTENT.placeHolderText}
           onInputChanged={onInputChanged}
-          clearButton={false}
           formatOnFocusOut
-          suffix
         />
         {showTwitterShare && (
           <TweetShare

--- a/client/src/pages/TwitterPage/TwitterPage.tsx
+++ b/client/src/pages/TwitterPage/TwitterPage.tsx
@@ -6,7 +6,6 @@ import { FadeLoader } from 'react-spinners';
 import Cookies from 'js-cookie';
 
 import AddressWidget from '../../components/AddressWidget';
-import TwitterMeta from '../../components/TwitterMeta/TwitterMeta';
 import TweetShare from '../../components/TweetShare/TweetShare';
 import { FCHBanner } from '../../components/FCHBanner';
 import { FCHSpecialsBanner } from '../../components/SpecialsBanner';
@@ -192,6 +191,10 @@ const TwitterPage: React.FC<Props & RouteComponentProps> = props => {
     return value;
   };
 
+  const onTweetShareClicked = () => {
+    setStartVerification(true);
+  };
+
   const handleRedirect = useCallback(
     (count: number) => {
       fireAnalyticsEvent(
@@ -250,7 +253,6 @@ const TwitterPage: React.FC<Props & RouteComponentProps> = props => {
         onUserVerify();
       } else {
         setShowTwitterShare(true);
-        setStartVerification(true);
       }
     }
   };
@@ -285,7 +287,6 @@ const TwitterPage: React.FC<Props & RouteComponentProps> = props => {
 
   return (
     <>
-      <TwitterMeta />
       <div className={classes.container}>
         <AddressWidget
           {...ADDRESS_WIDGET_CONTENT}
@@ -312,6 +313,7 @@ const TwitterPage: React.FC<Props & RouteComponentProps> = props => {
             hashtags={TWITTER_SHARE_CONTENT.hashtags}
             via={TWITTER_SHARE_CONTENT.via}
             actionText={TWITTER_SHARE_CONTENT.actionText}
+            onTweetShareClicked={onTweetShareClicked}
             userfch={userfch}
           />
         )}

--- a/client/src/pages/TwitterPage/TwitterPage.tsx
+++ b/client/src/pages/TwitterPage/TwitterPage.tsx
@@ -182,6 +182,16 @@ const TwitterPage: React.FC<Props & RouteComponentProps> = props => {
     return convertedValue;
   };
 
+  const onInputChanged = (value: string) => {
+    if (showTwitterShare) {
+      setIsVerified(false);
+      setStartVerification(false);
+      setShowTwitterShare(false);
+    }
+
+    return value;
+  };
+
   const handleRedirect = useCallback(
     (count: number) => {
       fireAnalyticsEvent(
@@ -290,6 +300,7 @@ const TwitterPage: React.FC<Props & RouteComponentProps> = props => {
           }
           showSubmitButton={showSubmitButton}
           placeHolderText={ADDRESS_WIDGET_CONTENT.placeHolderText}
+          onInputChanged={onInputChanged}
           clearButton={false}
           formatOnFocusOut
           suffix

--- a/client/src/pages/TwitterPage/TwitterPage.tsx
+++ b/client/src/pages/TwitterPage/TwitterPage.tsx
@@ -122,6 +122,7 @@ const TwitterPage: React.FC<Props & RouteComponentProps> = props => {
       ? value
           .toLowerCase()
           .replaceAll('@', '')
+          .replace(/^_+|_+$/g, '')
           .replaceAll('_', '-')
       : value;
 
@@ -288,6 +289,8 @@ const TwitterPage: React.FC<Props & RouteComponentProps> = props => {
               : customHandleSubmitUnverified
           }
           showSubmitButton={showSubmitButton}
+          placeHolderText={ADDRESS_WIDGET_CONTENT.placeHolderText}
+          clearButton={false}
           formatOnFocusOut
           suffix
         />

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -38,6 +38,8 @@ export type ClickEventTypes = ReactMouseEvent<HTMLElement, MouseEvent> & {
   target: { blur: () => void };
 };
 
+export type EventObjectType = ReactMouseEvent<HTMLAnchorElement> | undefined;
+
 export type Domain = { domain: string; free?: boolean };
 
 export type ContainedFlowActionSettingsKey = keyof typeof CONTAINED_FLOW_ACTIONS;


### PR DESCRIPTION
- Change placeholder text from “Enter a Username“ to “Enter Twitter Handle“ like shown on designs
- Remove that X and move “@twitter” text closer to the right border of the field
- Twitter username that is entered in the textinput have underscores in the beginning or in the end they should be trimmed
- When user edits the handle back to a one that was just verified, the Verified banner re-appears
- Loader shouldn’t be shown until Tweet button on twittercard is clicked
- Fix clear button functionality for twitter input. 
- Add suffix input component.