### PR TITLE
Feature. DASH-906 Alternative sign transactions

### DIFF
--- a/client/src/components/MetamaskConfirmAction/MetamaskConfirmAction.tsx
+++ b/client/src/components/MetamaskConfirmAction/MetamaskConfirmAction.tsx
@@ -88,11 +88,7 @@ export const MetamaskConfirmAction: React.FC<Props> = props => {
       }
 
       if (returnOnlySignedTxn) {
-        onSuccess(
-          signedTxns.successed?.length === 1
-            ? signedTxns.successed[0]
-            : signedTxns.successed,
-        );
+        onSuccess(signedTxns.successed);
       } else {
         const pushTransactionResult = async (
           signedTxn: SignedTxArgs,

--- a/client/src/pages/CheckoutPage/CheckoutPageContext.tsx
+++ b/client/src/pages/CheckoutPage/CheckoutPageContext.tsx
@@ -486,12 +486,13 @@ export const useContext = (): {
 
     if (signTxItems.length) {
       return setBeforeSubmitProps({
-        walletConfirmType: WALLET_CREATED_FROM.EDGE,
+        walletConfirmType: paymentWallet.from,
         fee: new MathOp(prices?.nativeFio?.address)
           .mul(SIGN_TX_MAX_FEE_COEFF) // +50%
           .round(0, 2)
           .toNumber(),
         data: { fioAddressItems: signTxItems },
+        paymentWallet,
         onSuccess: (data: BeforeSubmitData) => {
           handleSubmit(data);
           dispatchSetProcessing(false);

--- a/client/src/pages/CheckoutPage/components/BeforeSubmitMetamaskWallet.tsx
+++ b/client/src/pages/CheckoutPage/components/BeforeSubmitMetamaskWallet.tsx
@@ -1,0 +1,128 @@
+import React, { useCallback, useState } from 'react';
+
+import {
+  MetamaskConfirmAction,
+  OnSuccessResponseResult,
+} from '../../../components/MetamaskConfirmAction';
+
+import {
+  ACTIONS,
+  DEFAULT_MAX_FEE_MULTIPLE_AMOUNT,
+  FIO_CONTRACT_ACCOUNT_NAMES,
+  TRANSACTION_ACTION_NAMES,
+  TRANSACTION_DEFAULT_OFFSET_EXPIRATION,
+} from '../../../constants/fio';
+
+import apis from '../../../api';
+
+import { ActionParams } from '../../../types/fio';
+import useEffectOnce from '../../../hooks/general';
+import MathOp from '../../../util/math';
+import {
+  BeforeSubmitData,
+  BeforeSubmitProps,
+  SignFioAddressItem,
+} from '../types';
+
+export const BeforeSubmitMetamaskWallet: React.FC<BeforeSubmitProps> = props => {
+  const {
+    data,
+    fee,
+    paymentWallet,
+    processing,
+    onCancel,
+    onSuccess,
+    setProcessing,
+  } = props;
+
+  const { fioAddressItems } = data || {};
+  const { publicKey, data: paymentWalletData } = paymentWallet || {};
+
+  const [actionParams, setActionParams] = useState<ActionParams[] | null>(null);
+  const [indexedItems, setIndexedItems] = useState<
+    Array<SignFioAddressItem & { indexId?: number }>
+  >(null);
+
+  const handleIndexedItems = useCallback(({ fioAddressItem, index }) => {
+    setIndexedItems(prevIndexedItem => {
+      if (prevIndexedItem) {
+        return [...prevIndexedItem, { ...fioAddressItem, indexId: index }];
+      } else {
+        return [{ ...fioAddressItem, indexId: index }];
+      }
+    });
+  }, []);
+
+  const handleResult = useCallback(
+    (result: OnSuccessResponseResult) => {
+      if (!result) return;
+
+      const signedTxs: BeforeSubmitData = {};
+
+      if (Array.isArray(result)) {
+        for (const resultItem of result) {
+          if ('signatures' in resultItem) {
+            const indexedItem = indexedItems.find(
+              indexedItem => indexedItem.indexId === Number(resultItem.id),
+            );
+
+            const signedTxItem = resultItem;
+            delete signedTxItem.id;
+
+            signedTxs[indexedItem.name] = {
+              signedTx: resultItem,
+              signingWalletPubKey: publicKey,
+            };
+          }
+        }
+        onSuccess(signedTxs);
+      }
+    },
+    [indexedItems, onSuccess, publicKey],
+  );
+
+  useEffectOnce(
+    () => {
+      const actionParamsArr = [];
+      for (const [index, fioAddressItem] of fioAddressItems.entries()) {
+        const fioHandleActionParams = {
+          action: TRANSACTION_ACTION_NAMES[ACTIONS.registerFioAddress],
+          account: FIO_CONTRACT_ACCOUNT_NAMES.fioAddress,
+          data: {
+            owner_fio_public_key: fioAddressItem.ownerKey,
+            fio_address: fioAddressItem.name,
+            tpid: apis.fio.tpid,
+            max_fee: new MathOp(fee)
+              .mul(DEFAULT_MAX_FEE_MULTIPLE_AMOUNT)
+              .round(0)
+              .toNumber(),
+          },
+          derivationIndex: paymentWalletData?.derivationIndex,
+          expirationOffset: TRANSACTION_DEFAULT_OFFSET_EXPIRATION,
+          id: index,
+        };
+
+        handleIndexedItems({ fioAddressItem, index });
+
+        actionParamsArr.push(fioHandleActionParams);
+      }
+
+      setActionParams(actionParamsArr);
+    },
+    [],
+    !!data,
+  );
+
+  if (!data) return null;
+
+  return (
+    <MetamaskConfirmAction
+      actionParams={actionParams}
+      processing={processing}
+      returnOnlySignedTxn
+      setProcessing={setProcessing}
+      onCancel={onCancel}
+      onSuccess={handleResult}
+    />
+  );
+};

--- a/client/src/pages/CheckoutPage/components/BeforeSubmitWalletConfirm.tsx
+++ b/client/src/pages/CheckoutPage/components/BeforeSubmitWalletConfirm.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import BeforeSubmitEdgeWallet from './BeforeSubmitEdgeWallet';
+import { BeforeSubmitMetamaskWallet } from './BeforeSubmitMetamaskWallet';
 
 import { WALLET_CREATED_FROM } from '../../../constants/common';
 
@@ -13,6 +14,9 @@ const BeforeSubmitWalletConfirm: React.FC<BeforeSubmitProps> = props => {
     <>
       {walletConfirmType === WALLET_CREATED_FROM.EDGE ? (
         <BeforeSubmitEdgeWallet {...props} />
+      ) : null}
+      {walletConfirmType === WALLET_CREATED_FROM.METAMASK ? (
+        <BeforeSubmitMetamaskWallet {...props} />
       ) : null}
     </>
   );

--- a/client/src/pages/CheckoutPage/types.d.ts
+++ b/client/src/pages/CheckoutPage/types.d.ts
@@ -68,6 +68,7 @@ export type BeforeSubmitState = {
     fioAddressItems: SignFioAddressItem[];
   } | null;
   fee?: number | null;
+  paymentWallet: FioWalletDoublet;
 };
 
 export type BeforeSubmitProps = {

--- a/client/src/pages/TokensRequestPaymentPage/PaymentDetailsPage.tsx
+++ b/client/src/pages/TokensRequestPaymentPage/PaymentDetailsPage.tsx
@@ -10,6 +10,7 @@ import FioLoader from '../../components/common/FioLoader/FioLoader';
 import WalletAction from '../../components/WalletAction/WalletAction';
 import LedgerWalletActionNotSupported from '../../components/LedgerWalletActionNotSupported';
 import PageTitle from '../../components/PageTitle/PageTitle';
+import { PaymentDetailsMetemaskWallet } from './components/PaymentDetailsMetemaskWallet';
 
 import { BADGE_TYPES } from '../../components/Badge/Badge';
 import { ROUTES } from '../../constants/routes';
@@ -190,6 +191,7 @@ const PaymentDetailsPage: React.FC<ContainerProps & LocationProps> = props => {
         action={CONFIRM_PIN_ACTIONS.SEND}
         FioActionWallet={PaymentDetailsEdgeWallet}
         LedgerActionWallet={LedgerWalletActionNotSupported}
+        MetamaskActionWallet={PaymentDetailsMetemaskWallet}
       />
 
       <PseudoModalContainer

--- a/client/src/pages/TokensRequestPaymentPage/components/PaymentDetailsMetemaskWallet.tsx
+++ b/client/src/pages/TokensRequestPaymentPage/components/PaymentDetailsMetemaskWallet.tsx
@@ -1,0 +1,118 @@
+import React, { useCallback } from 'react';
+
+import {
+  MetamaskConfirmAction,
+  OnSuccessResponseResult,
+} from '../../../components/MetamaskConfirmAction';
+
+import {
+  ACTIONS,
+  FIO_CONTENT_TYPES,
+  FIO_CONTRACT_ACCOUNT_NAMES,
+  TRANSACTION_ACTION_NAMES,
+} from '../../../constants/fio';
+
+import apis from '../../../api';
+import { DEFAULT_ACTION_FEE_AMOUNT } from '../../../api/fio';
+
+import { FioWalletDoublet } from '../../../types';
+import { PaymentDetailsValues, TxValues } from '../types';
+import { handleFioServerResponse } from '../../../util/fio';
+
+type Props = {
+  contactsList: string[];
+  fioWallet: FioWalletDoublet;
+  processing: boolean;
+  submitData: PaymentDetailsValues;
+  createContact: (name: string) => void;
+  onSuccess: (result: TxValues & { error?: string }) => void;
+  onCancel: () => void;
+  setProcessing: (processing: boolean) => void;
+};
+
+export const PaymentDetailsMetemaskWallet: React.FC<Props> = props => {
+  const {
+    contactsList,
+    fioWallet,
+    processing,
+    submitData,
+    createContact,
+    onCancel,
+    onSuccess,
+    setProcessing,
+  } = props;
+
+  const {
+    amount,
+    chainCode,
+    fioRequestId,
+    memo,
+    obtId,
+    tokenCode,
+    payeeFioAddress,
+    payerFioAddress,
+    payeePublicAddress,
+  } = submitData || {};
+
+  const { data, publicKey } = fioWallet || {};
+
+  const actionParams = {
+    action: TRANSACTION_ACTION_NAMES[ACTIONS.recordObtData],
+    account: FIO_CONTRACT_ACCOUNT_NAMES.fioRecordObt,
+    contentType: FIO_CONTENT_TYPES.RECORD_OBT_DATA,
+    data: {
+      content: {
+        amount: Number(amount),
+        chain_code: chainCode,
+        token_code: tokenCode,
+        payer_public_address: publicKey,
+        payee_public_address: payeePublicAddress,
+        memo: memo || '',
+        hash: '',
+        obt_id: obtId,
+        offline_url: '',
+        status: 'sent_to_blockchain',
+      },
+      fio_request_id: fioRequestId,
+      payer_fio_address: payerFioAddress,
+      payee_fio_address: payeeFioAddress,
+      tpid: apis.fio.tpid,
+      max_fee: DEFAULT_ACTION_FEE_AMOUNT,
+    },
+    derivationIndex: data?.derivationIndex,
+  };
+
+  const handleRecordObtResult = useCallback(
+    (result: OnSuccessResponseResult) => {
+      if (!result) return;
+
+      if (!contactsList.filter(c => c === payeeFioAddress).length)
+        createContact(payeeFioAddress);
+
+      if (!Array.isArray(result) && 'transaction_id' in result) {
+        const { status } = handleFioServerResponse(result);
+
+        const resultObj = {
+          blockNum: result.processed?.block_num,
+          status,
+          transactionId: result.transaction_id,
+        };
+
+        onSuccess(resultObj);
+      }
+    },
+    [contactsList, createContact, onSuccess, payeeFioAddress],
+  );
+
+  if (!submitData) return null;
+
+  return (
+    <MetamaskConfirmAction
+      actionParams={actionParams}
+      processing={processing}
+      setProcessing={setProcessing}
+      onCancel={onCancel}
+      onSuccess={handleRecordObtResult}
+    />
+  );
+};

--- a/client/src/pages/WalletsPage/WalletsPage.tsx
+++ b/client/src/pages/WalletsPage/WalletsPage.tsx
@@ -29,11 +29,12 @@ import { Props } from './types';
 import classes from './styles/WalletsPage.module.scss';
 
 type TitleComponentProps = {
+  isAlternativeAccountType: boolean;
   onAdd: () => void;
 };
 
 const TitleComponent: React.FC<TitleComponentProps> = props => {
-  const { onAdd } = props;
+  const { isAlternativeAccountType, onAdd } = props;
 
   return (
     <Title title="FIO Wallets">
@@ -45,12 +46,14 @@ const TitleComponent: React.FC<TitleComponentProps> = props => {
           </Button>
         </Link>
 
-        <Link to={ROUTES.IMPORT_WALLET} className={classes.actionButton}>
-          <Button>
-            <SystemUpdateAltIcon fontSize="small" />
-            <span>Import</span>
-          </Button>
-        </Link>
+        {!isAlternativeAccountType ? (
+          <Link to={ROUTES.IMPORT_WALLET} className={classes.actionButton}>
+            <Button>
+              <SystemUpdateAltIcon fontSize="small" />
+              <span>Import</span>
+            </Button>
+          </Link>
+        ) : null}
 
         <Button onClick={onAdd} className={classes.actionButton}>
           <AddCircleIcon />
@@ -65,6 +68,7 @@ const WalletsPage: React.FC<Props> = () => {
   const {
     fioWallets,
     fioWalletsBalances,
+    isAlternativeAccountType,
     showCreateWallet,
     showWalletCreated,
     showWalletDeleted,
@@ -85,7 +89,14 @@ const WalletsPage: React.FC<Props> = () => {
         onClose={closeCreateWallet}
         onWalletCreated={onWalletCreated}
       />
-      <LayoutContainer title={<TitleComponent onAdd={onAdd} />}>
+      <LayoutContainer
+        title={
+          <TitleComponent
+            onAdd={onAdd}
+            isAlternativeAccountType={isAlternativeAccountType}
+          />
+        }
+      >
         <NotificationBadge
           type={BADGE_TYPES.INFO}
           show={showWalletImported}

--- a/client/src/pages/WalletsPage/WalletsPageContext.tsx
+++ b/client/src/pages/WalletsPage/WalletsPageContext.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router';
 import { useSelector } from 'react-redux';
 
 import { fioWalletsBalances as fioWalletsBalancesSelector } from '../../redux/fio/selectors';
+import { user as userSelector } from '../../redux/profile/selectors';
 
 import {
   PAGE_TYPES,
@@ -18,6 +19,7 @@ import {
 } from '../../types';
 import useQuery from '../../hooks/useQuery';
 import { QUERY_PARAMS_NAMES } from '../../constants/queryParams';
+import { USER_PROFILE_TYPE } from '../../constants/profile';
 
 const AUTOCLOSE_TIME = 5000;
 const AUTOCLOSE_CREATE_WALLET_TIME = 10000;
@@ -25,6 +27,7 @@ const AUTOCLOSE_CREATE_WALLET_TIME = 10000;
 type UseContextProps = {
   fioWallets: FioWalletDoublet[];
   fioWalletsBalances: WalletsBalances;
+  isAlternativeAccountType: boolean;
   showCreateWallet: boolean;
   showWalletCreated: boolean;
   showWalletDeleted: boolean;
@@ -44,6 +47,7 @@ type UseContextProps = {
 
 export const useContext = (): UseContextProps => {
   const fioWalletsBalances = useSelector(fioWalletsBalancesSelector);
+  const user = useSelector(userSelector);
   const [showCreateWallet, setShowCreateWallet] = useState<boolean>(false);
   const [showWalletImported, setShowWalletImported] = useState<boolean>(false);
   const [showWalletCreated, setShowWalletCreated] = useState<boolean>(false);
@@ -119,6 +123,8 @@ export const useContext = (): UseContextProps => {
   return {
     fioWallets,
     fioWalletsBalances,
+    isAlternativeAccountType:
+      user?.userProfileType === USER_PROFILE_TYPE.ALTERNATIVE,
     showCreateWallet,
     showWalletCreated,
     showWalletDeleted,

--- a/client/src/types/fio.d.ts
+++ b/client/src/types/fio.d.ts
@@ -71,6 +71,7 @@ export type FioServerResponse = {
         response: string;
       };
     }>;
+    block_num: number;
   };
   transaction_id: string;
 };


### PR DESCRIPTION
- Add payment details action for metamask wallet.
- Add sign fio handles on private domains on non fio payment for metamask wallet.
- Hide Import wallets for alternative user account type.