### PR TITLE
Fix. DASH-963 handle metamask snap in metamask mobile app

### DIFF
--- a/client/src/components/LoginForm/components/MetamaskLogin/MetamaskLogin.module.scss
+++ b/client/src/components/LoginForm/components/MetamaskLogin/MetamaskLogin.module.scss
@@ -39,3 +39,8 @@
     font-size: 0.9375em;
   }
 }
+
+.errorMessage {
+  font-size: 13px !important;
+  letter-spacing: normal !important;
+}

--- a/client/src/components/LoginForm/components/MetamaskLogin/MetamaskLogin.tsx
+++ b/client/src/components/LoginForm/components/MetamaskLogin/MetamaskLogin.tsx
@@ -3,6 +3,10 @@ import React from 'react';
 import SubmitButton from '../../../common/SubmitButton/SubmitButton';
 import ModalComponent from '../../../Modal/Modal';
 import { MetamaskConnectionModal } from '../../../Modal/MetamaskConnectionModal';
+import NotificationBadge from '../../../NotificationBadge';
+import { BADGE_TYPES } from '../../../Badge/Badge';
+
+import { METAMASK_UNSUPPORTED_MOBILE_MESSAGE } from '../../../../constants/errors';
 
 import { useContext } from './MetamaskLoginContext';
 
@@ -23,6 +27,7 @@ export const MetamaskLogin: React.FC = () => {
   const {
     isDescriptionModalOpen,
     isLoginModalOpen,
+    isMobileDeviceWithMetamask,
     connectMetamask,
     onDetailsClick,
     onDescriptionModalClose,
@@ -31,6 +36,14 @@ export const MetamaskLogin: React.FC = () => {
 
   return (
     <>
+      <NotificationBadge
+        type={BADGE_TYPES.WARNING}
+        show={isMobileDeviceWithMetamask}
+        hasNewDesign
+        message={METAMASK_UNSUPPORTED_MOBILE_MESSAGE}
+        className={classes.errorBadge}
+        messageClassnames={classes.errorMessage}
+      />
       <SubmitButton
         text={
           <span className={classes.textContainer}>
@@ -45,6 +58,7 @@ export const MetamaskLogin: React.FC = () => {
         onClick={connectMetamask}
         withTopMargin
         withBottomMargin
+        disabled={isMobileDeviceWithMetamask}
       />
       <p className={classes.description} onClick={onDetailsClick}>
         Want more info on sign in with MetaMask?

--- a/client/src/components/LoginForm/components/MetamaskLogin/MetamaskLoginContext.tsx
+++ b/client/src/components/LoginForm/components/MetamaskLogin/MetamaskLoginContext.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { isMobile } from 'react-device-detect';
 
 import { MetamaskSnap } from '../../../../services/MetamaskSnap';
 import apis from '../../../../api';
@@ -21,6 +22,7 @@ const DEFAULT_METAMASK_ERROR =
 type UseContextProps = {
   isDescriptionModalOpen: boolean;
   isLoginModalOpen: boolean;
+  isMobileDeviceWithMetamask: boolean;
   connectMetamask: () => void;
   onDetailsClick: () => void;
   onDescriptionModalClose: () => void;
@@ -115,6 +117,7 @@ export const useContext = (): UseContextProps => {
   return {
     isDescriptionModalOpen,
     isLoginModalOpen,
+    isMobileDeviceWithMetamask: isMobile && window.ethereum?.isMetaMask,
     connectMetamask,
     onDetailsClick,
     onDescriptionModalClose,

--- a/client/src/constants/errors.ts
+++ b/client/src/constants/errors.ts
@@ -54,3 +54,6 @@ export const AUTHENTICATION_FAILED = 'AUTHENTICATION_FAILED';
 export const TWOFA_TOKEN_IS_NOT_VALID = '2FA_TOKEN_IS_NOT_VALID';
 
 export const ALREADY_REGISTERED_ERROR_TEXT = 'already registered';
+
+export const METAMASK_UNSUPPORTED_MOBILE_MESSAGE =
+  'Currenty Sign-in with MetaMask only works on Desktop with MetaMask browser extension v11.0 and up.';

--- a/client/src/pages/MetamaskGatedRegistration/MetamaskGatedRegistrationContext.tsx
+++ b/client/src/pages/MetamaskGatedRegistration/MetamaskGatedRegistrationContext.tsx
@@ -29,6 +29,7 @@ import { DOMAIN_TYPE, METAMASK_DOMAIN_NAME } from '../../constants/fio';
 import { CART_ITEM_TYPE } from '../../constants/common';
 import { ROUTES } from '../../constants/routes';
 import { USER_PROFILE_TYPE } from '../../constants/profile';
+import { METAMASK_UNSUPPORTED_MOBILE_MESSAGE } from '../../constants/errors';
 
 import metamaskAtLogoSrc from '../../assets/images/metamask-landing/metamask-at.svg';
 
@@ -49,6 +50,12 @@ const NOTIFICATIONS = {
     message:
       'Please ensure that the MetaMask browser extension is installed and active. Or refresh the page if it has just been installed.',
     title: 'MetaMask not detected.',
+  },
+  INSTALL_MOBILE_METAMASK: {
+    hasNotification: true,
+    type: BADGE_TYPES.WARNING,
+    message: METAMASK_UNSUPPORTED_MOBILE_MESSAGE,
+    title: 'MetaMask app is not supported.',
   },
   NON_VALID_FIO_HANDLE: {
     hasNotification: true,
@@ -143,11 +150,12 @@ export const useContext = (): UseContext => {
 
   const {
     isLoginModalOpen,
+    isMobileDeviceWithMetamask,
     connectMetamask,
     onLoginModalClose,
   } = useContextMetamaskLogin();
 
-  const isVerified = window.ethereum?.isMetaMask;
+  const isVerified = window.ethereum?.isMetaMask && !isMobileDeviceWithMetamask;
   const userHasMetamaskFioHandleInCart = cartItems.find(
     cartItem => cartItem.domain === METAMASK_DOMAIN_NAME,
   );
@@ -217,8 +225,12 @@ export const useContext = (): UseContext => {
   );
 
   const customHandleSubmitUnverified = useCallback(() => {
-    setNotification(NOTIFICATIONS.INSTALL_METAMASK);
-  }, []);
+    setNotification(
+      isMobileDeviceWithMetamask
+        ? NOTIFICATIONS.INSTALL_MOBILE_METAMASK
+        : NOTIFICATIONS.INSTALL_METAMASK,
+    );
+  }, [isMobileDeviceWithMetamask]);
 
   const handleAddCartItem = useCallback(
     async ({ address }: { address: string }): Promise<void> => {

--- a/client/src/pages/MetamaskLandingPage/MetamaskLandingPage.tsx
+++ b/client/src/pages/MetamaskLandingPage/MetamaskLandingPage.tsx
@@ -17,6 +17,7 @@ import NotificationBadge from '../../components/NotificationBadge';
 
 import { APP_TITLE } from '../../constants/labels';
 import { ROUTES } from '../../constants/routes';
+import { METAMASK_UNSUPPORTED_MOBILE_MESSAGE } from '../../constants/errors';
 
 import { useContext as useContextMetamaskLandgingPage } from './MetamaskLandingPageContext';
 
@@ -140,6 +141,7 @@ const MetamaskLandingPage: React.FC = () => {
   const {
     alternativeLoginError,
     isLoginModalOpen,
+    isMobileDeviceWithMetamask,
     noMetamaskExtention,
     handleConnectClick,
     onLoginModalClose,
@@ -185,6 +187,16 @@ const MetamaskLandingPage: React.FC = () => {
                   messageClassnames={classes.errorMessage}
                 />
               )}
+              {isMobileDeviceWithMetamask && (
+                <NotificationBadge
+                  type={BADGE_TYPES.WARNING}
+                  show={isMobileDeviceWithMetamask}
+                  hasNewDesign
+                  message={METAMASK_UNSUPPORTED_MOBILE_MESSAGE}
+                  className={classes.errorBadge}
+                  messageClassnames={classes.errorMessage}
+                />
+              )}
               <SubmitButton
                 text={
                   <>
@@ -198,6 +210,7 @@ const MetamaskLandingPage: React.FC = () => {
                 }
                 hasAutoHeight
                 hasAutoWidth
+                disabled={isMobileDeviceWithMetamask}
                 className={classes.button}
                 onClick={handleConnectClick}
               />

--- a/client/src/pages/MetamaskLandingPage/MetamaskLandingPage.tsx
+++ b/client/src/pages/MetamaskLandingPage/MetamaskLandingPage.tsx
@@ -60,6 +60,11 @@ const accordionContent = [
     title: 'Did the FIO MetaMask Snap pass any security audits?',
     text: 'Yes, it has been audited by Sayfer, an external audit team.',
   },
+  {
+    title: 'Can I use Snaps on both MetaMask Extension and Mobile App?',
+    text:
+      'Currently, Snaps are only available in the MetaMask browser extension v11.0 and up.',
+  },
 ];
 
 const featureItems = [

--- a/client/src/pages/MetamaskLandingPage/MetamaskLandingPageContext.tsx
+++ b/client/src/pages/MetamaskLandingPage/MetamaskLandingPageContext.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
+import { isMobile } from 'react-device-detect';
 
 import { useContext as useContextMetamaskLogin } from '../../components/LoginForm/components/MetamaskLogin/MetamaskLoginContext';
 
@@ -12,6 +13,7 @@ import { ROUTES } from '../../constants/routes';
 type Props = {
   alternativeLoginError: string;
   isLoginModalOpen: boolean;
+  isMobileDeviceWithMetamask: boolean;
   noMetamaskExtention: boolean;
   handleConnectClick: () => void;
   onLoginModalClose: () => void;
@@ -44,6 +46,7 @@ export const useContext = (): Props => {
   return {
     alternativeLoginError,
     isLoginModalOpen,
+    isMobileDeviceWithMetamask: isMobile && window.ethereum?.isMetaMask,
     noMetamaskExtention,
     handleConnectClick,
     onLoginModalClose,


### PR DESCRIPTION
- Add info about MetaMask snap into FAQ's MetaMask landing page
- Show unsupported MetaMask messages for MetaMask internal browser on mobile devices.